### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Every change to RiskKernel requires review from the maintainer.
+# (Pairs with the branch ruleset's "require code owner review" on main.)
+* @prashar32


### PR DESCRIPTION
Adds `.github/CODEOWNERS` (`* @prashar32`) so the branch ruleset's required code-owner review resolves to the maintainer. Admin-merged (bootstrap: the code-owner requirement can't be satisfied until this file exists).