### PR TITLE
feat: packaging + signed release pipeline; v0.1.0 quickstart

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Keep the build context small and free of local state/secrets.
+.git
+.github
+data
+*.db
+*.db-wal
+*.db-shm
+.env
+.env.*
+dist
+sdks/python
+examples
+docs
+*.md
+!README.md
+CLAUDE.md
+NoMerge.json
+2*.txt
+coverage.out
+coverage.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  # Multi-arch binaries, archives, checksums + the GitHub release.
+  goreleaser:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Multi-arch Docker image to GHCR, cosign-signed (keyless via OIDC).
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # cosign keyless signing
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: sigstore/cosign-installer@v3
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/prashar32/riskkernel
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+      - name: Build date
+        run: echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+      - id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            DATE=${{ env.BUILD_DATE }}
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes ghcr.io/prashar32/riskkernel@${DIGEST}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,62 @@
+# GoReleaser builds the multi-arch binaries, archives, and checksums and cuts the
+# GitHub release. The signed multi-arch Docker image is built and cosign-signed by
+# the release workflow (.github/workflows/release.yml) from the main Dockerfile.
+version: 2
+
+project_name: riskkernel
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: riskkernel
+    main: ./cmd/riskkernel
+    binary: riskkernel
+    env:
+      - CGO_ENABLED=0 # pure-Go SQLite (modernc) → fully static, cross-compiles
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/prashar32/riskkernel/internal/version.Version={{ .Version }}
+      - -X github.com/prashar32/riskkernel/internal/version.Commit={{ .ShortCommit }}
+      - -X github.com/prashar32/riskkernel/internal/version.Date={{ .Date }}
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+
+archives:
+  - id: default
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
+    files:
+      - LICENSE
+      - README.md
+      - SECURITY.md
+      - COMPATIBILITY.md
+
+checksum:
+  name_template: checksums.txt
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-snapshot"
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+
+release:
+  github:
+    owner: prashar32
+    name: riskkernel
+  draft: false
+  prerelease: auto
+  footer: |
+    ---
+    Self-hosted. Your keys. No telemetry. See SECURITY.md to verify.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 # Changelog
 
 All notable changes to RiskKernel are documented here. The format follows
-[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims to
-follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once `v0.1.0` ships.
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 We ship loudly: every user-facing change lands here, and the stability of each
 surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
+
+## [0.1.0] - 2026-05-31
+
+The first release: the deterministic reliability runtime for AI agents —
+governor, proxy, crash-resume, observability, human-in-the-loop, MCP governance,
+and a memory you own, in one self-hosted binary. Three integration surfaces
+(proxy, Python SDK, OpenTelemetry), Apache-2.0, no telemetry.
 
 ### Added
 - **Public contract (`api/v1`)** — OpenAPI 3.1 spec for the versioned REST surface:
@@ -87,5 +94,10 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
   key/value) persist in SQLite (migration `00004`). `GET /v1/memory`,
   `GET /v1/memory/entry`, `GET`/`PUT /v1/memory/facts`; `riskkernel memory
   list/show`; Python SDK `list_memory`/`read_memory`/`list_facts`/`put_fact`.
+- **Packaging & release** — single static binary (`make build`); cross-compiled
+  multi-arch Docker image (distroless, nonroot) on GHCR, **cosign-signed**
+  (keyless) on each `v*` tag; GoReleaser binaries + checksums + GitHub release;
+  `govulncheck` + CodeQL in CI. One-line `docker run` quickstart.
 
-[Unreleased]: https://github.com/prashar32/riskkernel/commits/main
+[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/prashar32/riskkernel/releases/tag/v0.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# --- build: pure-Go static binary (no cgo, thanks to modernc.org/sqlite) ---
+# Runs on the builder's native platform and cross-compiles to the target, so
+# multi-arch builds don't pay the QEMU tax for the Go compile.
+FROM --platform=$BUILDPLATFORM golang:1.23 AS build
+WORKDIR /src
+
+# Cache deps first.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath \
+    -ldflags="-s -w \
+      -X github.com/prashar32/riskkernel/internal/version.Version=${VERSION} \
+      -X github.com/prashar32/riskkernel/internal/version.Commit=${COMMIT} \
+      -X github.com/prashar32/riskkernel/internal/version.Date=${DATE}" \
+    -o /out/riskkernel ./cmd/riskkernel
+
+# A /data dir owned by the nonroot uid so the default run works without a mount.
+RUN mkdir -p /data && chown 65532:65532 /data
+
+# --- runtime: distroless static, nonroot ---
+FROM gcr.io/distroless/static-debian12:nonroot
+LABEL org.opencontainers.image.source="https://github.com/prashar32/riskkernel"
+LABEL org.opencontainers.image.description="RiskKernel — the deterministic reliability runtime for AI agents"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+COPY --from=build /out/riskkernel /usr/local/bin/riskkernel
+COPY --from=build --chown=65532:65532 /data /data
+
+ENV RISKKERNEL_DATA_DIR=/data
+EXPOSE 7070
+VOLUME ["/data"]
+USER 65532:65532
+
+ENTRYPOINT ["/usr/local/bin/riskkernel"]
+CMD ["serve"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+# RiskKernel — common dev tasks. `make help` lists them.
+
+BINARY      := riskkernel
+PKG         := github.com/prashar32/riskkernel
+VERSION     ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT      ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+DATE        ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS     := -s -w \
+	-X $(PKG)/internal/version.Version=$(VERSION) \
+	-X $(PKG)/internal/version.Commit=$(COMMIT) \
+	-X $(PKG)/internal/version.Date=$(DATE)
+IMAGE       ?= ghcr.io/prashar32/riskkernel
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## List targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN{FS=":.*?## "}{printf "  %-14s %s\n", $$1, $$2}'
+
+.PHONY: build
+build: ## Build the static binary
+	CGO_ENABLED=0 go build -trimpath -ldflags="$(LDFLAGS)" -o $(BINARY) ./cmd/riskkernel
+
+.PHONY: test
+test: ## Run tests with the race detector
+	go test -race ./...
+
+.PHONY: vet
+vet: ## go vet
+	go vet ./...
+
+.PHONY: fmt
+fmt: ## Check formatting (fails if anything is unformatted)
+	@unformatted=$$(gofmt -l .); \
+	if [ -n "$$unformatted" ]; then echo "unformatted:"; echo "$$unformatted"; exit 1; fi
+
+.PHONY: vuln
+vuln: ## Run govulncheck
+	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+.PHONY: check
+check: fmt vet test ## fmt + vet + test
+
+.PHONY: sdk-test
+sdk-test: ## Run the Python SDK tests (stdlib only)
+	cd sdks/python && python3 -m unittest discover -s tests -t . -v
+
+.PHONY: docker
+docker: ## Build the Docker image locally
+	docker build \
+		--build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --build-arg DATE=$(DATE) \
+		-t $(IMAGE):$(VERSION) -t $(IMAGE):latest .
+
+.PHONY: run
+run: build ## Build and run the daemon
+	./$(BINARY) serve
+
+.PHONY: clean
+clean: ## Remove build artifacts
+	rm -f $(BINARY) coverage.out
+	rm -rf dist

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Deterministic cost / loop / time budgets · full observability · crash-resumabl
 Self-hosted. Your keys. No telemetry. Point it at your existing agents — one env var.
 
 [![CI](https://github.com/prashar32/riskkernel/actions/workflows/ci.yml/badge.svg)](https://github.com/prashar32/riskkernel/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/prashar32/riskkernel?sort=semver)](https://github.com/prashar32/riskkernel/releases)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/status-pre--v0.1-orange.svg)](CHANGELOG.md)
 
 </div>
 
@@ -41,16 +41,48 @@ It is **not** another gateway (LiteLLM/Portkey own routing), **not** another obs
 2. **Python SDK (deep control).** `pip install riskkernel`, then `@governed_run` / `@governed_tool` / `runtime.budget(...)` / `ApprovalGate`. Adapters for the Claude Agent SDK, OpenAI Agents SDK, and LangChain.
 3. **OpenTelemetry (universal).** RiskKernel is an OTLP endpoint *and* emitter — govern apps already instrumented with OpenLLMetry / the OpenAI Agents SDK, and export to the backend you already run.
 
-## Quickstart
+## Quickstart (60 seconds)
 
-> Status: **pre-v0.1, under active construction.** See [`docs/VISION.md`](docs/VISION.md) for scope and [`CHANGELOG.md`](CHANGELOG.md) for what has landed. This section becomes a working 60-second quickstart at the v0.1.0 tag.
+Run the daemon with a default per-run budget and your key (nothing leaves your
+machine except calls to the provider you choose):
 
 ```bash
-# build the single static binary
-go build -o riskkernel ./cmd/riskkernel
-export ANTHROPIC_API_KEY=sk-ant-...
-./riskkernel serve            # daemon on :7070
+docker run --rm -p 7070:7070 -v "$PWD/data:/data" \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  -e RISKKERNEL_DEFAULT_DOLLARS=0.50 \
+  ghcr.io/prashar32/riskkernel:latest
 ```
+
+Now put your **existing** OpenAI-compatible app under governance with **one env
+var** — no code changes — and point it at a Claude model:
+
+```bash
+export OPENAI_BASE_URL=http://localhost:7070/v1
+# your app runs unchanged; every call is metered, priced, budget-enforced
+```
+
+Or hit it directly and watch the governance headers:
+
+```bash
+curl -s -D- http://localhost:7070/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -H 'X-RiskKernel-Run-Id: demo' \
+  -d '{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hi"}]}'
+# → X-RiskKernel-Cost-Usd, X-RiskKernel-Tokens, X-RiskKernel-Step …
+# the run is killed with HTTP 402 the moment it exceeds $0.50.
+```
+
+Inspect and audit, all on your disk:
+
+```bash
+riskkernel runs list                 # every governed run
+riskkernel audit export <run-id>     # the cost ledger as JSON
+```
+
+Prefer a binary? `go build -o riskkernel ./cmd/riskkernel` (or `make build`), then
+`riskkernel serve`. Deeper control (loops, checkpoints, approval gates) is the
+Python SDK: `pip install riskkernel` — see [`sdks/python`](sdks/python). Trace
+every run in your own backend: [`examples/otel`](examples/otel).
 
 ## Design principles
 


### PR DESCRIPTION
## What & why

The packaging finish line for **v0.1** (§8 step 11): single binary, one-line `docker run`, and a signed release pipeline.

- **Dockerfile** — cross-compiled (no QEMU tax) pure-Go **static** binary on **distroless static, nonroot**; `/data` volume. `.dockerignore` keeps the context lean and secret-free.
- **`.goreleaser.yaml`** — multi-arch binaries (linux/darwin, amd64/arm64), archives, checksums, GitHub release notes; version stamped via ldflags.
- **`release.yml`** (on `v*` tags) — GoReleaser binaries + release; multi-arch image to **GHCR** built from the main Dockerfile and **cosign-signed keyless** (OIDC). `v*` tags are admin-only via the tag ruleset.
- **Makefile** — `build / test / vet / fmt / vuln / check / sdk-test / docker / run`.
- **README** — real **60-second quickstart** (docker run → one env var → governed call with cost headers → 402 on budget); release badge.
- **CHANGELOG** — `0.1.0` section.

## Definition of done (v0.1) — all met
- Zero-code adoption via one env var (proxy) ✓
- Governor hard-stops every budget ✓
- A `SIGKILL`'d run resumes from its checkpoint ✓
- Steps/tools/tokens/cost visible locally **and** exportable as OTel ✓
- Side-effecting actions require approval ✓
- Nothing phones home ✓

## Verification
- `go test -race ./...`, Python SDK suite, `vet`, `gofmt` all green.
- `make build` stamps version via ldflags. (Docker image + cosign run on the `v*` tag.)

`v0.1.0` is tagged separately after this merges (tagging triggers the signed release build + GHCR image)
