### PR TITLE
ci: add Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,47 @@
+name: Claude PR Review
+
+# Automatic reviewer-POV review when a PR to main is opened. Auth is the Claude
+# Max subscription via CLAUDE_CODE_OAUTH_TOKEN (no API billing, no per-call cost) —
+# generate it locally once with `claude setup-token` and add it as a repo secret.
+# Re-review on demand by commenting "@claude" (see claude.yml). Add `synchronize`
+# below if you also want a fresh review on every push.
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request as a senior reviewer for RiskKernel — a
+            deterministic, self-hosted reliability runtime for AI agents. Post
+            concise, actionable inline comments on the specific lines; if the PR
+            is clean, say so briefly. Prioritise:
+
+            1. Correctness & bugs — concurrency, error handling, edge cases.
+            2. Security — path/SSRF/injection, integer overflow, unsafe file or
+               exec handling, and secret handling. No data may leave the host
+               except calls to the user-configured provider, OTLP, and approval
+               webhook endpoints (see SECURITY.md).
+            3. The core invariant — ALL enforcement (token/dollar/loop/time
+               budgets, kill switch, approval gating, routing, retries,
+               checkpoint/resume) stays deterministic Go and is NEVER delegated to
+               an LLM.
+            4. Backwards compatibility — api/v1 request/response shapes, the config
+               schema, and SQLite migrations (forward-only; never edit a shipped
+               migration).
+            5. Tests — safety-critical paths (governor, approval gate, checkpoint
+               manager) need exhaustive coverage.
+            6. Surface any new CodeQL-style risks (e.g. tainted input reaching a
+               file path or a command) before they land.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,32 @@
+name: Claude (@claude)
+
+# On-demand Claude — comment "@claude ..." on a PR (or an inline review comment)
+# to ask for a re-review or a change. Locked to the maintainer: the job only runs
+# when the commenter is prashar32, so nobody else can invoke Claude on this repo.
+# Auth is the Claude Max subscription (CLAUDE_CODE_OAUTH_TOKEN); no API billing.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude:
+    # Only the maintainer can trigger Claude, and only via the @claude phrase.
+    if: >
+      github.event.sender.login == 'prashar32' &&
+      contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          trigger_phrase: "@claude"


### PR DESCRIPTION
Adds Claude-powered PR review using the **Claude Max subscription** (no `ANTHROPIC_API_KEY`, no API billing, no per-call cost). Two workflows:

- **`claude-pr-review.yml`** — automatic reviewer-POV review when a PR to `main` is opened/reopened, with a prompt specialized to RiskKernel's invariants (deterministic-only-in-Go enforcement, no-telemetry egress, `api/v1`/config/forward-only-migration compatibility, safety-critical tests, tainted-input/overflow risks). Add `synchronize` to also review every push.
- **`claude.yml`** — on-demand `@claude` on PR/review comments, **locked to the maintainer**: the job runs only when `github.event.sender.login == 'prashar32'`, so nobody else can invoke Claude on this repo.

## Setup required before it works
1. Generate a subscription token locally (one-time): `claude setup-token` — uses the Claude Max plan, prints a long-lived token once.
2. Add it as repo secret **`CLAUDE_CODE_OAUTH_TOKEN`** (Settings → Secrets and variables → Actions).
3. Install the **Claude GitHub App**: https://github.com/apps/claude

Auth is `claude_code_oauth_token` (not `anthropic_api_key`). Permissions are scoped to `contents: read` + `pull-requests: write` (+ `issues: write` for the `@claude` flow). Neither workflow is a required status check, so they don't block merges.
