### PR TITLE
fix(ci): grant id-token: write to the Claude workflows

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write # required: the action authenticates to GitHub via OIDC
 
 jobs:
   review:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write # required: the action authenticates to GitHub via OIDC
 
 jobs:
   claude:


### PR DESCRIPTION
The `@claude` run on PR #13 failed with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

`anthropics/claude-code-action` authenticates to GitHub by minting a token via **OIDC**, which requires the `id-token: write` permission. Both Claude workflows were missing it (they had `contents: read` + `pull-requests: write` (+ `issues: write`)).

This adds `id-token: write` to **`claude.yml`** and **`claude-pr-review.yml`**.

### After this merges
Because `issue_comment` workflows run from the **default branch**, the fix only takes effect once this is on `main`. Then post a fresh `@claude` comment to trigger a successful run. (Opening this PR may also exercise the auto-review path from the branch, which now has the permission.)