### PR TITLE
feat: add a Docker HEALTHCHECK for the daemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,9 @@ EXPOSE 7070
 VOLUME ["/data"]
 USER 65532:65532
 
+# distroless has no shell/curl, so the binary probes itself (GET /healthz).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD ["/usr/local/bin/riskkernel", "healthcheck"]
+
 ENTRYPOINT ["/usr/local/bin/riskkernel"]
 CMD ["serve"]

--- a/cmd/riskkernel/healthcheck.go
+++ b/cmd/riskkernel/healthcheck.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prashar32/riskkernel/internal/config"
+)
+
+// runHealthcheck probes the daemon's /healthz endpoint and exits non-zero if it
+// is not OK. It backs the Docker HEALTHCHECK — the distroless image has no shell
+// or curl, so the binary checks itself.
+func runHealthcheck(_ []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/healthz", cfg.Port)
+	client := &http.Client{Timeout: 4 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("healthcheck: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("healthcheck: unhealthy (status %d)", resp.StatusCode)
+	}
+	return nil
+}

--- a/cmd/riskkernel/main.go
+++ b/cmd/riskkernel/main.go
@@ -48,6 +48,8 @@ func main() {
 		err = runApprovals(args)
 	case "memory":
 		err = runMemory(args)
+	case "healthcheck":
+		err = runHealthcheck(args)
 	case "version", "--version", "-v":
 		fmt.Println("riskkernel", version.String())
 	case "help", "--help", "-h":
@@ -78,6 +80,7 @@ Usage:
   riskkernel approvals deny <id> [--reason ...]     Deny a pending request
   riskkernel memory list [namespace]                List git-native memory entries
   riskkernel memory show <name> [namespace]         Print a memory file
+  riskkernel healthcheck        Probe /healthz (used by the Docker HEALTHCHECK)
   riskkernel version            Print build identity
   riskkernel help               Show this help
 


### PR DESCRIPTION
The Docker image had no `HEALTHCHECK`, so orchestrators couldn't tell when the container was healthy. Since the distroless image has no shell or curl, this adds a **`riskkernel healthcheck`** subcommand (GETs `/healthz`, exits non-zero when unhealthy) and wires it into the Dockerfile `HEALTHCHECK`.

Fixes #14

Verified locally: `riskkernel healthcheck` exits 1 when the daemon is down and 0 when it's up.