### PR TITLE
fix: align Dockerfile Go version with go.mod (release blocker)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ labeled [`good first issue`](https://github.com/prashar32/riskkernel/labels/good
 
 ## Getting started
 
-Requires **Go 1.23+** (the daemon is pure-Go, no cgo) and, for SDK work, Python
-3.9+.
+Requires **Go 1.25+** (matches the `go` directive in `go.mod`; the daemon is
+pure-Go, no cgo) and, for SDK work, Python 3.9+.
 
 ```bash
 git clone https://github.com/prashar32/riskkernel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # --- build: pure-Go static binary (no cgo, thanks to modernc.org/sqlite) ---
 # Runs on the builder's native platform and cross-compiles to the target, so
 # multi-arch builds don't pay the QEMU tax for the Go compile.
-FROM --platform=$BUILDPLATFORM golang:1.23 AS build
+# NOTE: keep this >= the `go` directive in go.mod (currently 1.25.x), or the build
+# fails with "go.mod requires go >= ..." (the image pins GOTOOLCHAIN=local).
+FROM --platform=$BUILDPLATFORM golang:1.25 AS build
 WORKDIR /src
 
 # Cache deps first.


### PR DESCRIPTION
**Release blocker found during pre-release container testing.** `docker build` failed at `go mod download`:

```
go: go.mod requires go >= 1.25.7 (running go 1.23.12; GOTOOLCHAIN=local)
```

A dependency forces the `go.mod` `go` directive to **1.25.7**, but the Dockerfile build stage pinned `golang:1.23`. CI didn't catch it (Actions use `go-version-file: go.mod`; only the Dockerfile hardcoded a version), and `release.yml`'s Docker build would have failed the same way on the `v0.1.0` tag.

**Fix:** bump the build stage to `golang:1.25` (≥ the go.mod directive) and align `CONTRIBUTING.md` ("Go 1.25+").

**Verified locally** (`make docker` + run):
- Image rebuilds clean — **19.6 MB**, runs **nonroot (65532)**.
- `/healthz` → 200, `/version` stamped, in-container `HEALTHCHECK` exits 0.
- Governor enforces a loop budget (3rd step → **402**) inside the container.

Fixes #20

⚠️ This should merge **before** tagging `v0.1.0`, or the release image build will fail.