### PR TITLE
fix(sdk): include package files in the built wheel (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
 
+### Fixed
+- **Python SDK packaged an empty wheel** — `pip install riskkernel` (and installing
+  the SDK by path) installed no modules, so `import riskkernel` failed. The project
+  sits in a repo subdirectory and hatchling's VCS file selector excluded the package
+  files; selecting from the filesystem (`ignore-vcs`) fixes it. ([#32](https://github.com/prashar32/riskkernel/issues/32))
+
 ## [0.1.0] - 2026-05-31
 
 The first release: the deterministic reliability runtime for AI agents —

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -28,5 +28,12 @@ Source = "https://github.com/prashar32/riskkernel"
 langchain = ["langchain-core"]
 dev = ["pytest"]
 
+# This project lives in a subdirectory (sdks/python) of the repo. Hatchling's
+# VCS-aware file selector lists tracked files relative to the repo root, which
+# don't match the project-root-relative `packages` include — so the wheel comes
+# out empty. Selecting files from the filesystem instead of git fixes it. (#32)
+[tool.hatch.build]
+ignore-vcs = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["riskkernel"]


### PR DESCRIPTION
Closes #32.

## Problem
`pip install riskkernel` (and installing the SDK by path, as `examples/codebase-qa` does) installed a package with **no modules** — `import riskkernel` raised `ModuleNotFoundError`. The wheel hatchling built contained only `*.dist-info`.

## Cause
The SDK project lives in a repo **subdirectory** (`sdks/python`). Hatchling's default VCS-aware file selector lists tracked files with paths relative to the **repo root** (`sdks/python/riskkernel/...`), which don't match the project-root-relative `packages = ["riskkernel"]` include — so the build matched no files. `make sdk-test` didn't catch it because it runs against the source tree on `PYTHONPATH`, not an installed wheel.

## Fix
One line in `sdks/python/pyproject.toml`:
```toml
[tool.hatch.build]
ignore-vcs = true
```
Hatchling now selects files from the filesystem. Verified: the wheel ships all 9 modules and imports cleanly (including the lazy adapters submodule).

```
$ pip wheel ./sdks/python -w /tmp/w
$ python -c "import zipfile,glob; print(len([n for n in zipfile.ZipFile(glob.glob('/tmp/w/riskkernel-*.whl')[0]).namelist() if n.endswith('.py')]))"
9
$ pip install /tmp/w/riskkernel-*.whl && python -c "import riskkernel; print('ok')"
ok
```

This is release-worthy on its own — suggest a fast **v0.1.1**.

## Follow-up (separate)
Add a CI step that builds the wheel and imports `riskkernel` *from the installed wheel* (not source), so packaging regressions are caught — noted in #32.