### PR TITLE
release: v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-05-31
+
+A fast follow-up to v0.1.0: makes the Python SDK installable from a build, and
+ships a runnable demo of the headline feature (deterministic budget/loop governance
+killing a runaway agent).
+
 ### Added
 - **`examples/codebase-qa`** — a runnable demo agent (Python SDK + proxy) that
   showcases the headline feature: a real ReAct loop over a codebase that the
@@ -112,5 +118,6 @@ and a memory you own, in one self-hosted binary. Three integration surfaces
   (keyless) on each `v*` tag; GoReleaser binaries + checksums + GitHub release;
   `govulncheck` + CodeQL in CI. One-line `docker run` quickstart.
 
-[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/prashar32/riskkernel/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/prashar32/riskkernel/releases/tag/v0.1.0

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -71,7 +71,7 @@ orchestration inside the runtime, and a required heavyweight datastore.
 
 ## Status & roadmap
 
-Pre-v0.1, under active construction. The runtime is the entire current focus. See
+v0.1.1 (released). The runtime is the entire current focus. See
 [`CHANGELOG.md`](../CHANGELOG.md) for what has landed and the public contract in
 [`api/v1/`](../api/v1) for the stable surface SDKs build on.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ package version
 // These are set via -ldflags "-X github.com/prashar32/riskkernel/internal/version.Version=..."
 var (
 	// Version is the semantic version of this build.
-	Version = "0.1.0-dev"
+	Version = "0.1.2-dev"
 	// Commit is the git commit this binary was built from.
 	Commit = "unknown"
 	// Date is the build date (RFC3339), stamped at release.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "riskkernel"
-version = "0.1.0.dev0"
+version = "0.1.1"
 description = "Thin Python client for the RiskKernel reliability runtime (Surface 2)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdks/python/riskkernel/__init__.py
+++ b/sdks/python/riskkernel/__init__.py
@@ -37,7 +37,7 @@ from .runtime import (
     governed_run,
 )
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.1"
 
 __all__ = [
     "RiskKernel",


### PR DESCRIPTION
Release prep for **v0.1.1** — the version markers that don't auto-update (CLAUDE.md §13).

## What's in v0.1.1
- **Fixed:** Python SDK packaged an empty wheel — `pip install` installed no modules (#32). Now installable; the built wheel is `riskkernel-0.1.1` with all 9 modules.
- **Added:** `examples/codebase-qa` — a runnable demo of the headline feature (governor killing a runaway agent).

(Also merged since v0.1.0 but not user-facing, so not in the changelog: #36 skip auto-review on fork PRs.)

## Marker bumps
| File | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → dated `[0.1.1]`; fresh empty `[Unreleased]`; compare links |
| `docs/VISION.md` | status line → `v0.1.1 (released)` |
| `internal/version/version.go` | default `0.1.0-dev` → `0.1.2-dev` (stamped real via `-ldflags`) |
| `sdks/python` | `pyproject.toml` + `__init__.__version__` → `0.1.1` |

## After merge (tagging is manual — your call)
1. `git tag -a v0.1.1 -m "v0.1.1" && git push origin v0.1.1` → release workflow builds + cosign-signs the multi-arch GHCR image and GoReleaser binaries.
2. Verify: `docker run ghcr.io/prashar32/riskkernel:0.1.1 version` and `cosign verify …`.

## Not in this release (queued for v0.1.2)
#34 (halt status persistence), #35 (audit json tags — contributor PR), govulncheck toolchain bump, #37/#38 (usage rollup / tool_calls read API), and the two minor nits.