### PR TITLE
fix(examples): make codebase-qa requirements.txt work from any directory

### DIFF
--- a/examples/codebase-qa/requirements.txt
+++ b/examples/codebase-qa/requirements.txt
@@ -1,5 +1,8 @@
-# The only dependency is the RiskKernel Python SDK (which is stdlib-only itself —
-# the agent uses urllib for the proxy call, no requests/httpx needed).
-# The SDK isn't on PyPI yet, so install it from this repo. From this directory:
-#     pip install -r requirements.txt
-../../sdks/python
+# The only dependency is the RiskKernel Python SDK (stdlib-only itself — the agent
+# uses urllib for the proxy call, no requests/httpx). It isn't on PyPI yet, so it's
+# installed from source. This direct reference works from ANY directory (pip
+# resolves a bare relative path against your CWD, not this file, which is brittle):
+riskkernel @ git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python
+
+# Working inside a clone and want your local SDK instead? From THIS directory:
+#     pip install ../../sdks/python


### PR DESCRIPTION
## Problem
`pip install -r examples/codebase-qa/requirements.txt` from the repo root fails:

```
ERROR: Invalid requirement: '../../sdks/python' ... File '../../sdks/python' does not exist.
```

pip resolves a bare relative path in a requirements file against the **current working directory**, not the file's location. The pinned `../../sdks/python` only resolved if you happened to run pip from inside `examples/codebase-qa/`.

## Fix
Use a PEP 508 direct reference (the same from-source install the README now uses), which is CWD-independent:

```
riskkernel @ git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python
```

Kept the local-clone path (`pip install ../../sdks/python` from the example dir) as a documented alternative for contributors who want their working copy.

**Verified:** `pip install -r examples/codebase-qa/requirements.txt` from the repo root now installs `riskkernel 0.1.1` and imports.