### PR TITLE
Fix audit export totals JSON keys

### DIFF
--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -147,6 +148,37 @@ func TestLedgerAndTotals(t *testing.T) {
 	}
 	if d := totals.Dollars; d < 0.0359 || d > 0.0361 {
 		t.Errorf("totals.Dollars = %v, want ~0.036", d)
+	}
+}
+
+func TestLedgerTotalsJSONTags(t *testing.T) {
+	totals := LedgerTotals{
+		RunID:            "run-3",
+		Calls:            2,
+		PromptTokens:     300,
+		CompletionTokens: 130,
+		Dollars:          0.036,
+	}
+
+	b, err := json.Marshal(totals)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	for _, key := range []string{"runId", "calls", "promptTokens", "completionTokens", "dollars"} {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("JSON key %q missing from %s", key, string(b))
+		}
+	}
+	for _, key := range []string{"RunID", "Calls", "PromptTokens", "CompletionTokens", "Dollars"} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("unexpected Go field name %q in %s", key, string(b))
+		}
 	}
 }
 

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -113,11 +113,11 @@ type ApprovalRecord struct {
 
 // LedgerTotals aggregates spend for audit/reporting.
 type LedgerTotals struct {
-	RunID            string
-	Calls            int64
-	PromptTokens     int64
-	CompletionTokens int64
-	Dollars          float64
+	RunID            string  `json:"runId"`
+	Calls            int64   `json:"calls"`
+	PromptTokens     int64   `json:"promptTokens"`
+	CompletionTokens int64   `json:"completionTokens"`
+	Dollars          float64 `json:"dollars"`
 }
 
 // UsageGroup is one bucket of aggregated spend — e.g. one team, one provider, or


### PR DESCRIPTION
## Summary

- Add JSON tags to `storage.LedgerTotals`
- Keep `riskkernel audit export` totals consistent with the rest of the JSON output
- Add a regression test that rejects capitalized Go field names in the serialized totals object

Fixes prashar32/riskkernel#30

## Testing

- `go test ./internal/storage -run TestLedgerTotalsJSONTags -count=1`
- `go test ./...`
