### PR TITLE
fix(mcp): audit allowlist-blocked tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
   showed it as `running`. The halt (and its reason) is now persisted on that path,
   matching the token/dollar halt behavior. ([#34](https://github.com/prashar32/riskkernel/issues/34))
 
+### Changed
+- **MCP gateway audits allowlist-blocked tool calls.** A `tools/call` refused by the
+  allowlist is now recorded in the `tool_calls` audit trail (status `blocked`)
+  instead of being dropped silently — a refused call is part of the audit record.
+
 ## [0.1.1] - 2026-05-31
 
 A fast follow-up to v0.1.0: makes the Python SDK installable from a build, and

--- a/internal/mcp/gateway.go
+++ b/internal/mcp/gateway.go
@@ -106,16 +106,19 @@ func (g *Gateway) handle(w http.ResponseWriter, r *http.Request) {
 	_ = json.Unmarshal(req.Params, &params)
 	tool := params.Name
 
-	// 1) Allowlist (deterministic).
+	run := g.resolveRun(r)
+	stepIdx := run.View().Usage.Loops
+
+	// 1) Allowlist (deterministic). A blocked attempt is recorded too — a refused
+	// tool call is part of the audit trail, not a silent drop.
 	if !g.allowed(tool) {
 		g.log.Warn("mcp tool blocked by allowlist", "tool", tool)
+		g.recordToolCall(run.ID, stepIdx, tool, "", params.Arguments, "blocked")
 		writeRPCError(w, req.ID, -32001, "tool not allowed by policy: "+tool)
 		return
 	}
 
-	run := g.resolveRun(r)
 	sideEffect := g.sideEffect(tool)
-	stepIdx := run.View().Usage.Loops
 
 	// 2) Approval gate for side-effecting tools (blocks until resolved or timeout).
 	if sideEffect != "" {

--- a/internal/mcp/gateway_test.go
+++ b/internal/mcp/gateway_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -84,6 +85,47 @@ func TestAllowlistBlocks(t *testing.T) {
 	}
 	if *hits != 0 {
 		t.Fatal("blocked tool must NOT reach upstream")
+	}
+}
+
+// spyStore records every tool-call audit row written through it (there is no
+// tool_calls read API yet — that's #38 — so the test observes the writes directly).
+type spyStore struct {
+	storage.Store
+	mu      sync.Mutex
+	records []storage.ToolCallRecord
+}
+
+func (s *spyStore) AppendToolCall(ctx context.Context, t storage.ToolCallRecord) error {
+	s.mu.Lock()
+	s.records = append(s.records, t)
+	s.mu.Unlock()
+	return s.Store.AppendToolCall(ctx, t)
+}
+
+func TestAllowlistBlockIsAudited(t *testing.T) {
+	base, err := storage.OpenSQLite(filepath.Join(t.TempDir(), "audit.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = base.Close() })
+	spy := &spyStore{Store: base}
+	log := slog.New(slog.NewTextHandler(discard{}, nil))
+	gate := approval.NewGate(spy, approval.Policy{DefaultSafe: true}, nil, log)
+	mgr := runs.NewManager(governor.Budget{}).WithStore(spy, log)
+	// Upstream is intentionally unreachable: a blocked tool must never be forwarded.
+	g := New("http://127.0.0.1:1", []string{"safe_*"}, nil, gate, mgr, spy, time.Second, log)
+
+	w := httptest.NewRecorder()
+	g.handle(w, mcpReq(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"danger_rm","arguments":{"path":"/etc"}}}`))
+
+	if e := rpcError(t, w); e == nil || e["code"].(float64) != -32001 {
+		t.Fatalf("expected allowlist error, got %v", e)
+	}
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if len(spy.records) != 1 || spy.records[0].Tool != "danger_rm" || spy.records[0].Status != "blocked" {
+		t.Fatalf("blocked tool not audited: %+v", spy.records)
 	}
 }
 


### PR DESCRIPTION
A v0.1.2 polish nit (from the launch-readiness review).

## Problem
The MCP gateway's allowlist check returned **before** run resolution, so a `tools/call` blocked by policy was never written to the `tool_calls` audit trail — a silent drop in the "prove what an agent did" audit record.

## Fix
Resolve the run first, then record the blocked attempt (`status="blocked"`, no side-effect) before refusing it with `-32001`. Blocked tools still never reach the upstream (unchanged).

## Tests
`TestAllowlistBlockIsAudited` — uses a spy `Store` to observe the write, since `tool_calls` has no read API yet (that's #38). Existing MCP tests (forward, read-only, approve, deny, block) still pass; `go vet` + gofmt clean.