### PR TITLE
fix(memory): accept extension-less memory entry names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
   showed it as `running`. The halt (and its reason) is now persisted on that path,
   matching the token/dollar halt behavior. ([#34](https://github.com/prashar32/riskkernel/issues/34))
 
+### Changed
+- **Memory entry lookup accepts a name without its extension** — `GET
+  /v1/memory/entry?name=runbook` now resolves `runbook.md` (it previously required
+  the exact filename and 404'd otherwise). Path-traversal safety is unchanged.
+
 ## [0.1.1] - 2026-05-31
 
 A fast follow-up to v0.1.0: makes the Python SDK installable from a build, and

--- a/internal/memory/reader.go
+++ b/internal/memory/reader.go
@@ -59,6 +59,10 @@ var memoryExts = map[string]string{
 	".txt":      "text",
 }
 
+// extOrder is the deterministic preference order for extension-less lookups (map
+// iteration is randomized, so resolution must not depend on memoryExts ordering).
+var extOrder = []string{".md", ".markdown", ".yaml", ".yml", ".txt"}
+
 // List returns the memory entries under namespace (recursively). A missing
 // directory yields an empty list, not an error.
 func (r *Reader) List(namespace string) ([]Entry, error) {
@@ -100,9 +104,10 @@ func (r *Reader) List(namespace string) ([]Entry, error) {
 	return out, nil
 }
 
-// Read returns the content and metadata of a memory entry.
+// Read returns the content and metadata of a memory entry. The name may omit the
+// file extension (e.g. "runbook" resolves to "runbook.md").
 func (r *Reader) Read(namespace, name string) (string, Entry, error) {
-	p, err := r.resolveFile(namespace, name)
+	p, resolved, err := r.resolveReadable(namespace, name)
 	if err != nil {
 		return "", Entry{}, err
 	}
@@ -119,11 +124,40 @@ func (r *Reader) Read(namespace, name string) (string, Entry, error) {
 	}
 	info, _ := os.Stat(p)
 	e := Entry{
-		Namespace: namespace, Name: filepath.ToSlash(name), Format: format,
+		Namespace: namespace, Name: filepath.ToSlash(resolved), Format: format,
 		Size: sizeOf(info), ModTime: modTime(info),
 	}
-	e.Title, e.Description = titleFrom(string(data), name, format)
+	e.Title, e.Description = titleFrom(string(data), resolved, format)
 	return string(data), e, nil
+}
+
+// resolveReadable maps a (namespace, name) to an existing file path and the name
+// that matched. It tries the literal name first; on a miss, and only if the name
+// has no recognized memory extension, it tries name + each known extension (so
+// "runbook" finds "runbook.md"). Path-traversal is rejected up front by
+// resolveFile/safeJoin, before any extension fallback.
+func (r *Reader) resolveReadable(namespace, name string) (string, string, error) {
+	p, err := r.resolveFile(namespace, name)
+	if err != nil {
+		return "", "", err // e.g. path escapes the memory root — never fall through
+	}
+	if fi, statErr := os.Stat(p); statErr == nil && !fi.IsDir() {
+		return p, name, nil
+	}
+	if _, known := memoryExts[strings.ToLower(filepath.Ext(name))]; known {
+		return "", "", ErrNotFound // already had a known extension; don't stack another
+	}
+	for _, ext := range extOrder {
+		cand := name + ext
+		cp, err := r.resolveFile(namespace, cand)
+		if err != nil {
+			continue
+		}
+		if fi, statErr := os.Stat(cp); statErr == nil && !fi.IsDir() {
+			return cp, cand, nil
+		}
+	}
+	return "", "", ErrNotFound
 }
 
 // Search returns entries in a namespace whose title, name, or content contains

--- a/internal/memory/reader_test.go
+++ b/internal/memory/reader_test.go
@@ -70,6 +70,26 @@ func TestRead(t *testing.T) {
 	}
 }
 
+func TestRead_ExtensionlessName(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "runbook.md", "# Deploy\nbuild, sign, push")
+	r := NewReader(root)
+
+	// "runbook" (no extension) resolves to "runbook.md".
+	content, e, err := r.Read("", "runbook")
+	if err != nil {
+		t.Fatalf("extensionless Read: %v", err)
+	}
+	if content != "# Deploy\nbuild, sign, push" || e.Name != "runbook.md" || e.Format != "markdown" {
+		t.Fatalf("resolved wrong: content=%q entry=%+v", content, e)
+	}
+
+	// A genuinely missing extension-less name is still ErrNotFound.
+	if _, _, err := r.Read("", "nope"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
 func TestSearch(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "ns/a.md", "talks about postgres")


### PR DESCRIPTION
A v0.1.2 polish nit (from the launch-readiness review).

## Problem
`GET /v1/memory/entry?name=runbook` returned 404 — the read required the exact filename (`runbook.md`). Minor, but a confusing first-use papercut.

## Fix
`Reader.Read` tries the literal name first; on a miss (and only if the name has no recognized memory extension) it tries `name + ext` for each known extension (`.md`, `.markdown`, `.yaml`, `.yml`, `.txt`) in a deterministic order. Path traversal is rejected up front by `resolveFile`/`safeJoin` **before** any fallback, so the traversal guarantees are unchanged.

## Tests
`TestRead_ExtensionlessName` (resolves `runbook` → `runbook.md`; genuinely-missing name still `ErrNotFound`). Existing `TestRead` + `TestPathTraversalRejected` still pass; `go vet` + gofmt clean.

Note: this and #47 both add a bullet to `## [Unreleased]`, so whichever merges second may need a one-line CHANGELOG merge — I can resolve it (or roll both into the v0.1.2 release PR).