### PR TITLE
release: v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,21 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-06-01
+
+A polish release: correctness and UX fixes, plus a cleaner audit-export shape.
+No breaking changes; forward-compatible with existing v0.1.x state.
+
 ### Fixed
 - **Loop/time-budget halts now persist the run status.** A run halted on its loop
   or wall-clock budget is enforced in `BeginStep`/`CanProceed`, which returned
   before writing through — so `runs list`, `audit`, and `GET /v1/runs/{id}` still
   showed it as `running`. The halt (and its reason) is now persisted on that path,
   matching the token/dollar halt behavior. ([#34](https://github.com/prashar32/riskkernel/issues/34))
+- **`audit export` totals use API-style JSON keys** — `storage.LedgerTotals` now
+  carries json tags, so the `totals` object emits `runId`/`calls`/`promptTokens`/…
+  to match the rest of the API instead of capitalized Go field names. Thanks
+  @yzhkali! ([#30](https://github.com/prashar32/riskkernel/issues/30))
 
 ### Changed
 - **MCP gateway audits allowlist-blocked tool calls.** A `tools/call` refused by the
@@ -133,6 +142,7 @@ and a memory you own, in one self-hosted binary. Three integration surfaces
   (keyless) on each `v*` tag; GoReleaser binaries + checksums + GitHub release;
   `govulncheck` + CodeQL in CI. One-line `docker run` quickstart.
 
-[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/prashar32/riskkernel/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/prashar32/riskkernel/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/prashar32/riskkernel/releases/tag/v0.1.0

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -71,7 +71,7 @@ orchestration inside the runtime, and a required heavyweight datastore.
 
 ## Status & roadmap
 
-v0.1.1 (released). The runtime is the entire current focus. See
+v0.1.2 (released). The runtime is the entire current focus. See
 [`CHANGELOG.md`](../CHANGELOG.md) for what has landed and the public contract in
 [`api/v1/`](../api/v1) for the stable surface SDKs build on.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ package version
 // These are set via -ldflags "-X github.com/prashar32/riskkernel/internal/version.Version=..."
 var (
 	// Version is the semantic version of this build.
-	Version = "0.1.2-dev"
+	Version = "0.1.3-dev"
 	// Commit is the git commit this binary was built from.
 	Commit = "unknown"
 	// Date is the build date (RFC3339), stamped at release.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "riskkernel"
-version = "0.1.1"
+version = "0.1.2"
 description = "Thin Python client for the RiskKernel reliability runtime (Surface 2)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdks/python/riskkernel/__init__.py
+++ b/sdks/python/riskkernel/__init__.py
@@ -37,7 +37,7 @@ from .runtime import (
     governed_run,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = [
     "RiskKernel",


### PR DESCRIPTION
Release prep for **v0.1.2** — the version markers that don't auto-update (§13). A low-risk polish patch ahead of launch; no breaking changes.

## What's in v0.1.2
**Fixed**
- #34 — loop/time-budget halts now persist the run status (`runs list`/`audit`/`GET` no longer show a killed run as `running`).
- #30 — `audit export` totals use API-style JSON keys (`runId`/`calls`/…). Thanks @yzhkali (#35).

**Changed**
- #47 — MCP gateway records allowlist-blocked tool calls in the audit trail (`blocked`).
- #48 — memory entry lookup accepts a name without its extension (`runbook` → `runbook.md`).

## Marker bumps
| File | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → dated `[0.1.2]`; fresh `[Unreleased]`; compare links |
| `docs/VISION.md` | status → `v0.1.2 (released)` |
| `internal/version/version.go` | default → `0.1.3-dev` |
| `sdks/python` | `pyproject.toml` + `__init__.__version__` → `0.1.2` |

## After merge (tagging is manual)
1. **`git checkout main && git pull` first** (the §13 guard — so the tag lands on the release commit, not a stale one).
2. `git tag -a v0.1.2 -m "v0.1.2" && git push origin v0.1.2` → release workflow builds + cosign-signs the multi-arch GHCR image and binaries.
3. Verify: `docker pull … && docker run ghcr.io/prashar32/riskkernel:0.1.2 version` + `cosign verify …`.

This is the commit to launch on.