### PR TITLE
Surface tool call audit trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Inspect and audit, all on your disk:
 ```bash
 riskkernel runs list                 # every governed run
 riskkernel audit export <run-id>     # the cost ledger as JSON
+riskkernel audit tools <run-id>      # governed tool calls as JSON
 ```
 
 Prefer a binary? `go build -o riskkernel ./cmd/riskkernel` (or `make build`), then

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -88,6 +88,28 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /v1/runs/{id}/tool-calls:
+    get:
+      tags: [runs]
+      operationId: listToolCalls
+      summary: List governed tool calls for a run
+      description: Returns the MCP tool-call audit trail recorded for the run.
+      parameters:
+        - $ref: '#/components/parameters/RunId'
+      responses:
+        '200':
+          description: Tool calls in audit order.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ToolCall'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /v1/runs/{id}/approve:
     post:
       tags: [approvals]
@@ -575,6 +597,38 @@ components:
           format: date-time
         usage:
           $ref: '#/components/schemas/Usage'
+
+    ToolCall:
+      type: object
+      required: [id, runId, stepIndex, tool, status, createdAt]
+      description: A governed MCP tool call recorded in the run audit trail.
+      properties:
+        id:
+          type: string
+          format: uuid
+        runId:
+          type: string
+          format: uuid
+        stepIndex:
+          type: integer
+          format: int32
+        tool:
+          type: string
+          description: The tool invoked by the agent.
+        sideEffect:
+          type: string
+          description: Classified side effect, if any.
+        arguments:
+          type: object
+          additionalProperties: true
+          description: The tool-call arguments recorded for audit.
+        status:
+          type: string
+          description: The governance outcome recorded for the call.
+          enum: [pending, approved, denied, blocked, timeout]
+        createdAt:
+          type: string
+          format: date-time
 
     ApprovalRequest:
       type: object

--- a/cmd/riskkernel/admin.go
+++ b/cmd/riskkernel/admin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"text/tabwriter"
+	"time"
 
 	"github.com/prashar32/riskkernel/internal/app"
 	"github.com/prashar32/riskkernel/internal/config"
@@ -152,14 +153,22 @@ func maxFloat(a, b float64) float64 {
 	return b
 }
 
-// runAudit implements `riskkernel audit export <run-id>` — emit the auditable
-// cost ledger for a run as JSON. Everything touching money must be auditable.
+// runAudit implements the local audit read-back commands.
 func runAudit(args []string) error {
-	if len(args) < 2 || args[0] != "export" {
-		return fmt.Errorf("usage: riskkernel audit export <run-id>")
+	if len(args) < 2 {
+		return fmt.Errorf("usage: riskkernel audit <export|tools> <run-id>")
 	}
-	runID := args[1]
+	switch args[0] {
+	case "export":
+		return auditExport(args[1])
+	case "tools":
+		return auditTools(args[1])
+	default:
+		return fmt.Errorf("unknown audit subcommand %q (want export|tools)", args[0])
+	}
+}
 
+func auditExport(runID string) error {
 	store, err := openStoreForCLI()
 	if err != nil {
 		return err
@@ -178,16 +187,79 @@ func runAudit(args []string) error {
 	if err != nil {
 		return err
 	}
+	toolCalls, err := store.ListToolCalls(ctx, runID)
+	if err != nil {
+		return err
+	}
 
 	out := struct {
-		RunID   string                `json:"run_id"`
-		Totals  storage.LedgerTotals  `json:"totals"`
-		Entries []storage.LedgerEntry `json:"entries"`
-	}{RunID: runID, Totals: totals, Entries: ledger}
+		RunID     string                `json:"run_id"`
+		Totals    storage.LedgerTotals  `json:"totals"`
+		Entries   []storage.LedgerEntry `json:"entries"`
+		ToolCalls []toolCallJSON        `json:"tool_calls"`
+	}{RunID: runID, Totals: totals, Entries: ledger, ToolCalls: toolCallJSONSlice(toolCalls)}
 
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(out)
+}
+
+func auditTools(runID string) error {
+	store, err := openStoreForCLI()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	if _, err := store.GetRun(ctx, runID); err != nil {
+		return fmt.Errorf("run %s: %w", runID, err)
+	}
+	toolCalls, err := store.ListToolCalls(ctx, runID)
+	if err != nil {
+		return err
+	}
+
+	out := struct {
+		RunID     string         `json:"run_id"`
+		ToolCalls []toolCallJSON `json:"tool_calls"`
+	}{RunID: runID, ToolCalls: toolCallJSONSlice(toolCalls)}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+type toolCallJSON struct {
+	ID         string         `json:"id"`
+	RunID      string         `json:"runId"`
+	StepIndex  int32          `json:"stepIndex"`
+	Tool       string         `json:"tool"`
+	SideEffect string         `json:"sideEffect"`
+	Arguments  map[string]any `json:"arguments"`
+	Status     string         `json:"status"`
+	CreatedAt  time.Time      `json:"createdAt"`
+}
+
+func toolCallJSONSlice(calls []storage.ToolCallRecord) []toolCallJSON {
+	out := make([]toolCallJSON, 0, len(calls))
+	for _, call := range calls {
+		args := call.Arguments
+		if args == nil {
+			args = map[string]any{}
+		}
+		out = append(out, toolCallJSON{
+			ID:         call.ID,
+			RunID:      call.RunID,
+			StepIndex:  call.StepIndex,
+			Tool:       call.Tool,
+			SideEffect: call.SideEffect,
+			Arguments:  args,
+			Status:     call.Status,
+			CreatedAt:  call.CreatedAt,
+		})
+	}
+	return out
 }
 
 // openStoreForCLI opens the state store for a read-only CLI command.

--- a/cmd/riskkernel/admin_test.go
+++ b/cmd/riskkernel/admin_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prashar32/riskkernel/internal/storage"
+)
+
+func TestAuditToolsPrintsToolCalls(t *testing.T) {
+	dir := seedAuditStore(t)
+	t.Setenv("RISKKERNEL_DATA_DIR", dir)
+
+	out := captureStdout(t, func() error {
+		return runAudit([]string{"tools", "run-tools"})
+	})
+
+	var body struct {
+		RunID     string `json:"run_id"`
+		ToolCalls []struct {
+			ID         string         `json:"id"`
+			RunID      string         `json:"runId"`
+			StepIndex  int32          `json:"stepIndex"`
+			Tool       string         `json:"tool"`
+			SideEffect string         `json:"sideEffect"`
+			Arguments  map[string]any `json:"arguments"`
+			Status     string         `json:"status"`
+		} `json:"tool_calls"`
+	}
+	if err := json.Unmarshal(out, &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.RunID != "run-tools" || len(body.ToolCalls) != 1 {
+		t.Fatalf("body = %+v", body)
+	}
+	if got := body.ToolCalls[0]; got.ID != "tc-1" || got.RunID != "run-tools" ||
+		got.Tool != "mcp://shell" || got.SideEffect != "exec" ||
+		got.Arguments["cmd"] != "ls" || got.Status != "approved" {
+		t.Fatalf("tool call = %+v", got)
+	}
+}
+
+func TestAuditExportIncludesToolCalls(t *testing.T) {
+	dir := seedAuditStore(t)
+	t.Setenv("RISKKERNEL_DATA_DIR", dir)
+
+	out := captureStdout(t, func() error {
+		return runAudit([]string{"export", "run-tools"})
+	})
+
+	var body struct {
+		RunID     string          `json:"run_id"`
+		ToolCalls json.RawMessage `json:"tool_calls"`
+	}
+	if err := json.Unmarshal(out, &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.RunID != "run-tools" {
+		t.Fatalf("run_id = %q", body.RunID)
+	}
+	if !bytes.Contains(body.ToolCalls, []byte(`"mcp://shell"`)) {
+		t.Fatalf("tool_calls missing from export: %s", string(out))
+	}
+}
+
+func seedAuditStore(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := storage.OpenSQLite(filepath.Join(dir, "riskkernel.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	if err := s.UpsertRun(context.Background(), storage.RunRecord{
+		ID: "run-tools", Status: "running", CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendToolCall(context.Background(), storage.ToolCallRecord{
+		ID: "tc-1", RunID: "run-tools", StepIndex: 1, Tool: "mcp://shell",
+		SideEffect: "exec", Arguments: map[string]any{"cmd": "ls"}, Status: "approved", CreatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func captureStdout(t *testing.T, fn func() error) []byte {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	err = fn()
+	_ = w.Close()
+	os.Stdout = orig
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	return out
+}

--- a/cmd/riskkernel/main.go
+++ b/cmd/riskkernel/main.go
@@ -75,6 +75,7 @@ Usage:
   riskkernel runs list          List persisted governed runs
   riskkernel runs resume <id>   Show a run's resumable state after a crash
   riskkernel audit export <id>  Export a run's cost ledger as JSON
+  riskkernel audit tools <id>   Export a run's governed tool calls as JSON
   riskkernel approvals list     List pending human-in-the-loop approvals
   riskkernel approvals approve <id> [--reason ...]  Approve a pending request
   riskkernel approvals deny <id> [--reason ...]     Deny a pending request

--- a/internal/httpapi/runs.go
+++ b/internal/httpapi/runs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/prashar32/riskkernel/internal/approval"
 	"github.com/prashar32/riskkernel/internal/governor"
@@ -99,6 +100,34 @@ func (s *Server) handleCancelRun(w http.ResponseWriter, r *http.Request) {
 	httpx.WriteJSON(w, http.StatusOK, runViewFromManager(run))
 }
 
+// handleListToolCalls implements GET /v1/runs/{id}/tool-calls.
+func (s *Server) handleListToolCalls(w http.ResponseWriter, r *http.Request) {
+	runID := r.PathValue("id")
+	store := s.runs.Store()
+	if store == nil {
+		httpx.WriteError(w, http.StatusServiceUnavailable, "no_store", "no durable store configured")
+		return
+	}
+	if _, err := store.GetRun(r.Context(), runID); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			httpx.WriteError(w, http.StatusNotFound, "not_found", "run not found")
+			return
+		}
+		httpx.WriteError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	calls, err := store.ListToolCalls(r.Context(), runID)
+	if err != nil {
+		httpx.WriteError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	views := make([]toolCallView, 0, len(calls))
+	for _, call := range calls {
+		views = append(views, toolCallViewFromStorage(call))
+	}
+	httpx.WriteJSON(w, http.StatusOK, views)
+}
+
 type toolApprovalBody struct {
 	Tool       string         `json:"tool"`
 	SideEffect string         `json:"sideEffect"`
@@ -173,6 +202,34 @@ func writeHalt(w http.ResponseWriter, err error) {
 		return
 	}
 	httpx.WriteError(w, http.StatusInternalServerError, "internal_error", err.Error())
+}
+
+type toolCallView struct {
+	ID         string         `json:"id"`
+	RunID      string         `json:"runId"`
+	StepIndex  int32          `json:"stepIndex"`
+	Tool       string         `json:"tool"`
+	SideEffect string         `json:"sideEffect"`
+	Arguments  map[string]any `json:"arguments"`
+	Status     string         `json:"status"`
+	CreatedAt  time.Time      `json:"createdAt"`
+}
+
+func toolCallViewFromStorage(call storage.ToolCallRecord) toolCallView {
+	args := call.Arguments
+	if args == nil {
+		args = map[string]any{}
+	}
+	return toolCallView{
+		ID:         call.ID,
+		RunID:      call.RunID,
+		StepIndex:  call.StepIndex,
+		Tool:       call.Tool,
+		SideEffect: call.SideEffect,
+		Arguments:  args,
+		Status:     call.Status,
+		CreatedAt:  call.CreatedAt,
+	}
 }
 
 func runViewFromManager(run *runs.Run) map[string]any {

--- a/internal/httpapi/runs_test.go
+++ b/internal/httpapi/runs_test.go
@@ -1,11 +1,15 @@
 package httpapi
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/prashar32/riskkernel/internal/runs"
+	"github.com/prashar32/riskkernel/internal/storage"
 )
 
 func do(t *testing.T, h http.Handler, method, path, body string) *httptest.ResponseRecorder {
@@ -168,5 +172,43 @@ func TestRequestApproval_NotRequired(t *testing.T) {
 	_ = json.Unmarshal(w.Body.Bytes(), &ap)
 	if ap["status"] != "approved" || ap["required"] != false {
 		t.Fatalf("auto-approve response = %v", ap)
+	}
+}
+
+func TestListToolCalls(t *testing.T) {
+	srv, mgr, _ := newTestServer(t, "")
+	h := srv.Handler()
+	mgr.Create(runs.CreateOptions{ID: "run-tools"})
+	if err := mgr.Store().AppendToolCall(context.Background(), storage.ToolCallRecord{
+		ID: "tc-1", RunID: "run-tools", StepIndex: 1, Tool: "mcp://shell",
+		SideEffect: "exec", Arguments: map[string]any{"cmd": "ls"}, Status: "approved",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := do(t, h, http.MethodGet, "/v1/runs/run-tools/tool-calls", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var body []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body) != 1 {
+		t.Fatalf("tool calls = %+v", body)
+	}
+	if body[0]["id"] != "tc-1" || body[0]["runId"] != "run-tools" ||
+		body[0]["stepIndex"].(float64) != 1 || body[0]["sideEffect"] != "exec" ||
+		body[0]["status"] != "approved" {
+		t.Fatalf("tool call body = %+v", body[0])
+	}
+	args := body[0]["arguments"].(map[string]any)
+	if args["cmd"] != "ls" {
+		t.Fatalf("arguments = %+v", args)
+	}
+
+	w = do(t, h, http.MethodGet, "/v1/runs/missing/tool-calls", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("missing run status = %d, want 404", w.Code)
 	}
 }

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -65,6 +65,7 @@ func (s *Server) Handler() http.Handler {
 	if s.runs != nil {
 		mux.HandleFunc("GET /v1/checkpoints/{run_id}", s.requireAuth(s.handleGetCheckpoint))
 		mux.HandleFunc("GET /v1/runs/{id}", s.requireAuth(s.handleGetRun))
+		mux.HandleFunc("GET /v1/runs/{id}/tool-calls", s.requireAuth(s.handleListToolCalls))
 		// Run lifecycle control (Surface 2 — the Python SDK drives these).
 		mux.HandleFunc("POST /v1/runs", s.requireAuth(s.handleCreateRun))
 		mux.HandleFunc("POST /v1/runs/{id}/steps", s.requireAuth(s.handleBeginStep))

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -392,6 +392,30 @@ func (s *SQLite) AppendToolCall(ctx context.Context, t ToolCallRecord) error {
 	return nil
 }
 
+func (s *SQLite) ListToolCalls(ctx context.Context, runID string) ([]ToolCallRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, run_id, step_idx, tool, side_effect, arguments, status, created_at
+		FROM tool_calls WHERE run_id = ? ORDER BY step_idx, created_at, id`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list tool calls: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ToolCallRecord
+	for rows.Next() {
+		var t ToolCallRecord
+		var args, created string
+		if err := rows.Scan(&t.ID, &t.RunID, &t.StepIndex, &t.Tool,
+			&t.SideEffect, &args, &t.Status, &created); err != nil {
+			return nil, err
+		}
+		t.Arguments = unmarshalArgs(args)
+		t.CreatedAt = parseTime(created)
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
 // --- helpers ---
 
 type rowScanner interface {
@@ -438,6 +462,17 @@ func unmarshalMeta(s string) map[string]string {
 func orEmptyMap(m map[string]any) map[string]any {
 	if m == nil {
 		return map[string]any{}
+	}
+	return m
+}
+
+func unmarshalArgs(s string) map[string]any {
+	if s == "" || s == "{}" {
+		return nil
+	}
+	var m map[string]any
+	if json.Unmarshal([]byte(s), &m) != nil {
+		return nil
 	}
 	return m
 }

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -285,6 +285,48 @@ func TestToolCall(t *testing.T) {
 	}
 }
 
+func TestListToolCalls(t *testing.T) {
+	s := openTemp(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	mustRun(t, s, "run-tools", now)
+	mustRun(t, s, "other-run", now)
+
+	calls := []ToolCallRecord{
+		{
+			ID: "tc-1", RunID: "run-tools", StepIndex: 2, Tool: "mcp://shell",
+			SideEffect: "exec", Arguments: map[string]any{"cmd": "ls"}, Status: "approved", CreatedAt: now.Add(time.Second),
+		},
+		{
+			ID: "tc-2", RunID: "run-tools", StepIndex: 1, Tool: "mcp://fs",
+			SideEffect: "read", Arguments: map[string]any{"path": "/tmp/a"}, Status: "blocked", CreatedAt: now,
+		},
+		{
+			ID: "tc-other", RunID: "other-run", StepIndex: 1, Tool: "mcp://net",
+			Status: "approved", CreatedAt: now,
+		},
+	}
+	for _, call := range calls {
+		if err := s.AppendToolCall(ctx, call); err != nil {
+			t.Fatalf("AppendToolCall(%s): %v", call.ID, err)
+		}
+	}
+
+	got, err := s.ListToolCalls(ctx, "run-tools")
+	if err != nil {
+		t.Fatalf("ListToolCalls: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(ListToolCalls) = %d, want 2: %+v", len(got), got)
+	}
+	if got[0].ID != "tc-2" || got[1].ID != "tc-1" {
+		t.Fatalf("tool calls not ordered by step/time: %+v", got)
+	}
+	if got[0].Arguments["path"] != "/tmp/a" || got[1].Arguments["cmd"] != "ls" {
+		t.Fatalf("arguments did not round-trip: %+v", got)
+	}
+}
+
 func TestForeignKeyEnforced(t *testing.T) {
 	// A ledger entry for a non-existent run must be rejected (foreign_keys ON).
 	s := openTemp(t)

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -178,6 +178,8 @@ type Store interface {
 
 	// AppendToolCall records a tool invocation.
 	AppendToolCall(ctx context.Context, t ToolCallRecord) error
+	// ListToolCalls returns a run's tool invocations in audit order.
+	ListToolCalls(ctx context.Context, runID string) ([]ToolCallRecord, error)
 
 	// PutFact inserts or updates an episodic memory fact by (namespace, key).
 	PutFact(ctx context.Context, f Fact) error


### PR DESCRIPTION
## Summary

- Add storage read-back for governed tool calls by run
- Add GET /v1/runs/{id}/tool-calls
- Add riskkernel audit tools <run-id>
- Include tool calls in audit export output
- Document the new API/CLI surface and add coverage for storage, HTTP, and CLI

Fixes prashar32/riskkernel#38

## Testing

- go test ./...
