### PR TITLE
docs(changelog): record the tool_calls audit read-back (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
 
+### Added
+- **`tool_calls` audit trail is now readable** — `GET /v1/runs/{id}/tool-calls`,
+  `riskkernel audit tools <run-id>`, and a `tool_calls` array in `audit export`
+  surface the governed MCP tool-call record (it was previously write-only). Thanks
+  @Sebastefanelli! ([#38](https://github.com/prashar32/riskkernel/issues/38))
+
 ## [0.1.2] - 2026-06-01
 
 A polish release: correctness and UX fixes, plus a cleaner audit-export shape.


### PR DESCRIPTION
#50 merged without a CHANGELOG entry. Adds the `## [Unreleased]` → `### Added` bullet for the tool-calls audit read-back (`GET /v1/runs/{id}/tool-calls`, `riskkernel audit tools <run-id>`, and the `tool_calls` array in `audit export`), crediting @Sebastefanelli.

Doc-only; it'll roll into the v0.1.3 release notes.