### PR TITLE
feat(config): safe default budgets when none configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
   `riskkernel audit tools <run-id>`, and a `tool_calls` array in `audit export`
   surface the governed MCP tool-call record (it was previously write-only). Thanks
   @Sebastefanelli! ([#38](https://github.com/prashar32/riskkernel/issues/38))
+- **`docs/BUDGETS.md`** — the budget surface (cost/loop/time/tokens) defined in
+  one place as a public contract: the four dimensions, where they can be set,
+  precedence, halt semantics, and the stability promise.
+
+### Changed
+- **Safe default budgets out of the box.** A daemon started with *no*
+  `RISKKERNEL_DEFAULT_*` variable set now applies a conservative default budget
+  to runs created without an explicit one — **$5 / 100 loops / 1 hour per run**
+  — and logs it prominently at startup. Previously an unconfigured daemon left
+  runs unlimited, which is the wrong default for a reliability runtime.
+  *Behavior change:* setting any `RISKKERNEL_DEFAULT_*` variable (even to `0`,
+  meaning unlimited) is explicit control and disables the safe defaults
+  entirely — explicit configuration is always respected as-is.
 
 ## [0.1.2] - 2026-06-01
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -25,6 +25,7 @@ every exception here):
 | **Python SDK public methods** | Documented `@governed_run`, `@governed_tool`, `runtime.budget`, `runtime.checkpoint`, `ApprovalGate`. |
 | **OTel attribute names** | The `gen_ai.*` and `riskkernel.*` attribute set pinned in `api/v1/otel-genai.md`. |
 | **Plugin interfaces** | Go interfaces in `pkg/plugin/` (storage, memory, approval channel, provider). |
+| **Budget surface** | The `Budget` schema, `RISKKERNEL_DEFAULT_*` env vars, `X-RiskKernel-*` headers, 402 halt semantics, and `HaltReason` values, per [`docs/BUDGETS.md`](docs/BUDGETS.md). Safe-default *values* are tunable policy, not contract. |
 
 ### Not covered (may change at any time)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Self-hosted. Your keys. No telemetry. Point it at your existing agents — one e
 
 Production AI agents fail in the same handful of ways, every time: **runaway loops**, **surprise token bills**, **no failure recovery**, **no observability**, **no human-in-the-loop**, **no governance**. Agent *frameworks* (LangGraph, CrewAI, AutoGen) orchestrate the reasoning — but none of them ship the guardrails that keep a run from burning $400 in a midnight loop while you sleep.
 
-RiskKernel is the **deterministic, run-level reliability layer** that sits in front of your agents and enforces hard limits. The LLM proposes; deterministic Go code disposes. Every irreversible action is gated.
+RiskKernel is a **self-hosted agent reliability runtime** — the deterministic, run-level layer that sits in front of your agents and enforces hard limits. The LLM proposes; deterministic Go code disposes. Every irreversible action is gated.
 
 It is **not** another gateway (LiteLLM/Portkey own routing), **not** another observability dashboard (Langfuse/Phoenix own traces), and **not** a content-guardrails engine (Guardrails AI/NeMo own PII/jailbreak). It interoperates with all of those and competes on the one thing nobody ships in a single self-hosted binary: **deterministic run controls** — the agent SRE layer.
 
@@ -33,7 +33,7 @@ It is **not** another gateway (LiteLLM/Portkey own routing), **not** another obs
 
 | Capability | What it means |
 |---|---|
-| 💸 **Hard cost ceiling per run** | A run that hits its dollar/token budget is killed cleanly, state persisted. |
+| 💸 **Hard cost ceiling per run** | A run that hits its dollar/token budget is killed cleanly, state persisted. Safe defaults out of the box ([the budget contract](docs/BUDGETS.md)). |
 | 🔁 **Hard loop-iteration cap** | No more infinite agent loops. |
 | ⏱️ **Hard wall-clock budget** | Runs that exceed their time budget halt. |
 | 💾 **Crash-resumable checkpoints** | `SIGKILL` a run; `riskkernel runs resume <id>` picks up from the last step. |
@@ -49,8 +49,10 @@ It is **not** another gateway (LiteLLM/Portkey own routing), **not** another obs
 
 ## Quickstart (60 seconds)
 
-Run the daemon with a default per-run budget and your key (nothing leaves your
-machine except calls to the provider you choose):
+Run the daemon with your key (nothing leaves your machine except calls to the
+provider you choose). Unconfigured, every run gets a safe default budget —
+$5 / 100 loops / 1 hour — so nothing is ever unbounded; here we set an explicit
+50¢ cap (see [the budget contract](docs/BUDGETS.md)):
 
 ```bash
 docker run --rm -p 7070:7070 -v "$PWD/data:/data" \

--- a/docs/BUDGETS.md
+++ b/docs/BUDGETS.md
@@ -1,0 +1,142 @@
+# Budgets — the public contract
+
+This document defines RiskKernel's budget surface: the four budget dimensions,
+everywhere a budget can be set, the precedence between them, what happens when a
+limit trips, and what we promise to keep stable. If behavior and this document
+ever disagree, that's a bug — [open an issue](https://github.com/prashar32/riskkernel/issues).
+
+Budgets are the headline feature: **deterministic, run-level hard limits**
+enforced in Go before every model call and loop iteration. The same state always
+produces the same allow/halt decision — no LLM is ever consulted.
+
+## The four dimensions
+
+Every budget is per-run and has the same shape on every surface:
+
+| Dimension | Field / env suffix | Type | Meaning |
+|---|---|---|---|
+| Tokens | `tokens` / `_TOKENS` | int64 | Max total tokens (prompt + completion) across the run |
+| Dollars | `dollars` / `_DOLLARS` | float | Max cost in USD across the run, from the cost ledger |
+| Loops | `loops` / `_LOOPS` | int32 | Max agent loop iterations (steps) |
+| Seconds | `seconds` / `_SECONDS` | int32 | Max wall-clock duration of the run |
+
+Each limit is enforced independently; **the first to trip halts the run.** A
+value of `0` (or an omitted field) means *unlimited* for that dimension —
+subject to the safe defaults below.
+
+## Safe defaults (out-of-the-box behavior)
+
+A reliability runtime must be safe before it is configured. When the daemon
+starts with **no** `RISKKERNEL_DEFAULT_*` variable set, runs created without an
+explicit budget get the **safe default budget**:
+
+| | Safe default |
+|---|---|
+| Dollars | **$5.00** per run |
+| Loops | **100** per run |
+| Seconds | **3600** (1 hour) per run |
+| Tokens | unlimited (dollars caps spend) |
+
+The daemon logs this prominently at startup. Setting **any**
+`RISKKERNEL_DEFAULT_*` variable — even to `0` — is explicit control and
+disables the safe defaults entirely: each set value is used, and unset values
+mean unlimited. `RISKKERNEL_DEFAULT_DOLLARS=0` therefore restores fully
+unlimited runs, deliberately.
+
+## Where a budget can be set (precedence, highest first)
+
+1. **Per-run, inline** — the `budget` object on `POST /v1/runs` (or
+   `@governed_run(budget=...)` in the SDK). Overrides everything below,
+   field-by-field.
+2. **Policy bundle** — a named bundle registered via `POST /v1/policies` and
+   referenced by `policyRef` at run creation. An inline `budget` overrides the
+   bundle's default budget field-by-field.
+3. **Daemon default** — `RISKKERNEL_DEFAULT_TOKENS` / `_DOLLARS` / `_LOOPS` /
+   `_SECONDS`. Applied to runs created with neither an inline budget nor a
+   `policyRef` — e.g. proxy calls that supply only a run-id.
+4. **Safe defaults** — only when the daemon default is entirely unconfigured
+   (see above).
+
+## Surface 1 — Proxy (zero code)
+
+The proxy enforces the budget on every intercepted call. Group calls into a run
+with one request header; read enforcement state from the response headers:
+
+```
+request:   X-RiskKernel-Run-Id: <your-run-id>     # lazily creates the run under the default budget
+response:  X-RiskKernel-Cost-Usd, X-RiskKernel-Tokens, X-RiskKernel-Step, X-RiskKernel-Halt-Reason
+```
+
+Calls without a run-id header get a fresh ephemeral run (named `proxy`) under
+the default budget. When any limit trips, the call returns **HTTP 402** with the
+halt reason; no model call escapes the cap, and the run's state is persisted.
+
+The proxy alone cannot count your agent's *outer* loop — it sees model calls,
+not loop iterations. Loop budgets through the proxy cap model calls per run;
+for true loop-iteration enforcement use the SDK.
+
+## Surface 2 — Python SDK (deep control)
+
+```python
+from riskkernel import Budget, governed_run
+
+@governed_run(budget=Budget(dollars=2.50, loops=20, seconds=600))
+def my_agent():
+    run = current_run()
+    while True:
+        run.step()          # registers a loop iteration; raises BudgetExceeded when spent
+        ...                 # your model/tool calls, via the proxy or directly
+```
+
+`run.step()` calls `POST /v1/runs/{id}/steps`, which increments the loop counter
+and enforces the loop + time budgets in the Go core — the SDK carries no
+enforcement logic. `BudgetExceeded` is raised on 402; catch it for graceful
+shutdown, or let it terminate the run.
+
+## Surface 3 — REST API
+
+```
+POST /v1/runs                  {"budget": {"dollars": 2.5, "loops": 20}, ...}   # or "policyRef"
+POST /v1/runs/{id}/steps       402 + HaltReason when loop/time budget is spent
+POST /v1/runs/{id}/cancel      manual kill switch
+GET  /v1/runs/{id}             status, usage (tokens/dollars/loops/elapsedSeconds), haltReason
+```
+
+## Halt semantics
+
+When a limit trips, deterministically and atomically:
+
+1. The triggering call is refused — **HTTP 402** with a machine-readable reason.
+2. The run's status becomes `halted`, with `haltReason` one of
+   `token_budget_exceeded` | `dollar_budget_exceeded` | `loop_budget_exceeded` |
+   `time_budget_exceeded`.
+3. The halt and final usage are **persisted** — `riskkernel runs list`, the API,
+   and the audit export all show the halted state and the spend at halt.
+4. A halted run never silently continues. Crash-resume
+   (`riskkernel runs resume <id>`) is for *interrupted* runs; a budget-halted
+   run stays halted — start a new run with a bigger budget if that's what you
+   decide.
+
+Enforcement is checked **before every call and loop iteration** against the
+cumulative ledger: once the ceiling is reached, no further call begins. Cost
+per call is priced from provider-reported usage via the pricing table
+(config-updatable — provider pricing drifts), so a single in-flight call can
+land at, but never be issued past, the ceiling.
+
+## Stability promise
+
+The following are stable per [`COMPATIBILITY.md`](../COMPATIBILITY.md) across
+all v0.x minor versions:
+
+- The `Budget` schema field names and semantics (`tokens`, `dollars`, `loops`,
+  `seconds`; zero/omitted = unlimited).
+- The `RISKKERNEL_DEFAULT_*` environment variables and their explicit-control
+  semantics.
+- The `X-RiskKernel-*` header names.
+- HTTP 402 as the budget-halt status and the `HaltReason` enum values above
+  (values may be *added*, never renamed or removed within a major version).
+- SDK: `Budget`, `governed_run(budget=...)`, `run.step()`, `BudgetExceeded`.
+
+The *safe default values* ($5 / 100 loops / 1h) are sane-default policy, not
+contract: they may be tuned in a minor release (with a CHANGELOG entry), since
+anyone depending on exact limits should set them explicitly.

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -81,6 +81,19 @@ func Build(cfg *config.Config) (*Deps, error) {
 	}
 
 	prices := pricing.NewTable(nil)
+	if cfg.DefaultBudget.Defaulted {
+		log.Warn("no default budget configured — applying safe defaults",
+			"dollars", cfg.DefaultBudget.Dollars,
+			"loops", cfg.DefaultBudget.Loops,
+			"seconds", cfg.DefaultBudget.Seconds,
+			"hint", "set RISKKERNEL_DEFAULT_DOLLARS / _LOOPS / _SECONDS / _TOKENS to take explicit control (0 = unlimited)")
+	} else {
+		log.Info("default budget configured",
+			"tokens", cfg.DefaultBudget.Tokens,
+			"dollars", cfg.DefaultBudget.Dollars,
+			"loops", cfg.DefaultBudget.Loops,
+			"seconds", cfg.DefaultBudget.Seconds)
+	}
 	mgr := runs.NewManager(toGovernorBudget(cfg.DefaultBudget)).WithStore(store, log)
 	gw := gateway.New(registry, mgr, prices, tracer, log)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,17 @@ import (
 // DefaultPort is the daemon's default listen port.
 const DefaultPort = 7070
 
+// Safe default budget, applied only when the user configures no default budget
+// at all (none of the RISKKERNEL_DEFAULT_* variables set). A reliability
+// runtime must be safe out of the box — an unconfigured daemon should never
+// allow an unbounded run. Setting ANY RISKKERNEL_DEFAULT_* variable — even to
+// 0 (unlimited) — is an explicit choice and disables these entirely.
+const (
+	SafeDefaultDollars = 5.00 // max $ per run
+	SafeDefaultLoops   = 100  // max loop iterations per run
+	SafeDefaultSeconds = 3600 // max wall-clock per run (1h)
+)
+
 // Config is the resolved daemon configuration. Field documentation notes the
 // environment variable each value is read from.
 type Config struct {
@@ -37,7 +48,9 @@ type Config struct {
 	OpenAIAPIKey    string // OPENAI_API_KEY
 
 	// DefaultBudget is applied to runs created without an explicit budget — e.g.
-	// proxy calls that supply only a run-id. Any zero field is unlimited.
+	// proxy calls that supply only a run-id. Any zero field is unlimited. When no
+	// RISKKERNEL_DEFAULT_* variable is set at all, conservative safe defaults are
+	// applied instead (see SafeDefault*) and Defaulted is true.
 	DefaultBudget BudgetConfig
 
 	// OTel configures OpenTelemetry GenAI span export (Surface 3). Disabled unless
@@ -123,6 +136,11 @@ type BudgetConfig struct {
 	Dollars float64 // RISKKERNEL_DEFAULT_DOLLARS
 	Loops   int32   // RISKKERNEL_DEFAULT_LOOPS
 	Seconds int32   // RISKKERNEL_DEFAULT_SECONDS
+
+	// Defaulted is true when no RISKKERNEL_DEFAULT_* variable was set and the
+	// safe defaults were applied. Used for the prominent startup log only —
+	// enforcement treats the values identically.
+	Defaulted bool
 }
 
 // Load resolves configuration. It first loads KEY=VALUE pairs from .env (if
@@ -231,9 +249,19 @@ func loadOTel() OTelConfig {
 	}
 }
 
-// loadBudget reads the optional default-budget env vars. All are optional; an
-// unset or zero value means unlimited for that dimension.
+// loadBudget reads the optional default-budget env vars. When none is set the
+// safe defaults apply (see SafeDefault*). When at least one is set the user has
+// taken explicit control: each set value is used, and unset or zero values mean
+// unlimited for that dimension.
 func loadBudget() (BudgetConfig, error) {
+	if !anyBudgetEnvSet() {
+		return BudgetConfig{
+			Dollars:   SafeDefaultDollars,
+			Loops:     SafeDefaultLoops,
+			Seconds:   SafeDefaultSeconds,
+			Defaulted: true,
+		}, nil
+	}
 	var b BudgetConfig
 	var err error
 	if b.Tokens, err = envInt64("RISKKERNEL_DEFAULT_TOKENS"); err != nil {
@@ -253,6 +281,21 @@ func loadBudget() (BudgetConfig, error) {
 	}
 	b.Seconds = clampInt32(secs)
 	return b, nil
+}
+
+// anyBudgetEnvSet reports whether the user set any default-budget variable to a
+// non-empty value. An empty value is treated as unset, consistent with how each
+// variable is parsed individually.
+func anyBudgetEnvSet() bool {
+	for _, k := range []string{
+		"RISKKERNEL_DEFAULT_TOKENS", "RISKKERNEL_DEFAULT_DOLLARS",
+		"RISKKERNEL_DEFAULT_LOOPS", "RISKKERNEL_DEFAULT_SECONDS",
+	} {
+		if os.Getenv(k) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // clampInt32 narrows a non-negative int64 to int32, bounding it at math.MaxInt32

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,6 +43,59 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.DataDir != "./data" {
 		t.Errorf("DataDir = %q", cfg.DataDir)
 	}
+	// With no RISKKERNEL_DEFAULT_* set, the safe default budget must apply.
+	b := cfg.DefaultBudget
+	if !b.Defaulted {
+		t.Error("Defaulted = false, want true when no budget env vars are set")
+	}
+	if b.Dollars != SafeDefaultDollars || b.Loops != SafeDefaultLoops || b.Seconds != SafeDefaultSeconds {
+		t.Errorf("safe defaults = $%v/%d loops/%ds, want $%v/%d/%d",
+			b.Dollars, b.Loops, b.Seconds, SafeDefaultDollars, SafeDefaultLoops, SafeDefaultSeconds)
+	}
+	if b.Tokens != 0 {
+		t.Errorf("Tokens = %d, want 0 (unlimited — dollars caps spend)", b.Tokens)
+	}
+}
+
+func TestLoad_ExplicitBudgetDisablesSafeDefaults(t *testing.T) {
+	withCleanEnv(t)
+	chdirTemp(t)
+	// Setting any one variable — even to 0 — is explicit control: no safe
+	// defaults, unset dimensions are unlimited.
+	t.Setenv("RISKKERNEL_DEFAULT_DOLLARS", "0")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	b := cfg.DefaultBudget
+	if b.Defaulted {
+		t.Error("Defaulted = true, want false when a budget env var is set")
+	}
+	if b.Dollars != 0 || b.Loops != 0 || b.Seconds != 0 || b.Tokens != 0 {
+		t.Errorf("explicit budget = %+v, want all-zero (unlimited)", b)
+	}
+}
+
+func TestLoad_PartialExplicitBudget(t *testing.T) {
+	withCleanEnv(t)
+	chdirTemp(t)
+	t.Setenv("RISKKERNEL_DEFAULT_DOLLARS", "2.50")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	b := cfg.DefaultBudget
+	if b.Defaulted {
+		t.Error("Defaulted = true, want false")
+	}
+	if b.Dollars != 2.50 {
+		t.Errorf("Dollars = %v, want 2.50", b.Dollars)
+	}
+	if b.Loops != 0 || b.Seconds != 0 || b.Tokens != 0 {
+		t.Errorf("unset dimensions should stay unlimited, got %+v", b)
+	}
 }
 
 func TestLoad_EnvOverrides(t *testing.T) {
@@ -103,6 +156,8 @@ func withCleanEnv(t *testing.T) {
 	for _, k := range []string{
 		"RISKKERNEL_PORT", "RISKKERNEL_DATA_DIR", "RISKKERNEL_API_TOKEN",
 		"RISKKERNEL_DEFAULT_PROVIDER", "ANTHROPIC_API_KEY", "OPENAI_API_KEY",
+		"RISKKERNEL_DEFAULT_TOKENS", "RISKKERNEL_DEFAULT_DOLLARS",
+		"RISKKERNEL_DEFAULT_LOOPS", "RISKKERNEL_DEFAULT_SECONDS",
 	} {
 		t.Setenv(k, "")
 		os.Unsetenv(k)


### PR DESCRIPTION
An unconfigured daemon used to leave runs unlimited — the wrong default for a reliability runtime. Now, if no RISKKERNEL_DEFAULT_* var is set, runs created without an explicit budget get $5 / 100 loops / 1h per run, logged loudly at startup. Setting any budget var (even to 0) takes explicit control and disables the defaults entirely. Also adds docs/BUDGETS.md — the budget surface defined in one place as a public contract (dimensions, precedence, 402 halt semantics, stability promise) — linked from README and COMPATIBILITY.md."
