### PR TITLE
docs: document the one-line install (go install + SDK from source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,17 @@ riskkernel audit export <run-id>     # the cost ledger as JSON
 riskkernel audit tools <run-id>      # governed tool calls as JSON
 ```
 
-Prefer a binary? `go build -o riskkernel ./cmd/riskkernel` (or `make build`), then
-`riskkernel serve`. Deeper control (loops, checkpoints, approval gates) is the
-Python SDK — install it from source (PyPI publish is on the roadmap):
+Prefer a native binary to Docker? Install the CLI with one command — no clone
+needed — and run it:
+
+```bash
+go install github.com/prashar32/riskkernel/cmd/riskkernel@latest
+riskkernel serve
+```
+
+(or `make build` from a clone). Deeper control (loops, checkpoints, approval
+gates) is the Python SDK — install it from source (PyPI publish is on the
+roadmap):
 
 ```bash
 pip install "git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python"

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -8,7 +8,8 @@ SDK just makes governed runs ergonomic from Python. **Core install is stdlib-onl
 (no third-party dependencies).
 
 ```bash
-pip install riskkernel
+# Not on PyPI yet — install from source (the core is stdlib-only, so this is light):
+pip install "git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python"
 ```
 
 ## Quickstart


### PR DESCRIPTION
## What

Make installing RiskKernel a genuine one-liner on both surfaces.

- **CLI:** add the no-clone install — `go install github.com/prashar32/riskkernel/cmd/riskkernel@latest` — to the README quickstart. It previously showed only `go build -o … ./cmd/riskkernel`, which assumes you've cloned the repo.
- **SDK:** the SDK README still said `pip install riskkernel`, but the package isn't on PyPI yet — copy-pasting it fails. Point it at the install-from-source command, matching the main README. (PyPI publish stays on the roadmap.)

## Why

Adoption friction is the thing that kills a self-hosted runtime. The README is the conversion asset; the install commands in it have to actually work when pasted. The `go build` form needs a checkout, and the stale `pip install riskkernel` line errors out — both are friction for a first-time user.

## Notes

Docs only — no code or behavior change. `go install …@latest` verified to produce a working `riskkernel` binary in GOBIN; the from-source pip command is the same one the main README and `examples/codebase-qa` already use.