### PR TITLE
docs(examples): minimal "wrap your agent" governed loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Want to *see* the headline feature? [`examples/codebase-qa`](examples/codebase-q
 is a runnable agent that loops over a codebase until the governor kills it on its
 loop/dollar budget — the deterministic kill, end to end, with a real model.
 
+Brand new to the SDK? [`examples/wrap-your-agent`](examples/wrap-your-agent) is the
+no-key, two-minute version — a generic Python loop the governor caps at a loop
+budget, the deterministic kill with nothing running but the daemon.
+
 ## Design principles
 
 - **Deterministic core in Go.** All enforcement (budgets, kill switches, gating, routing, retries, checkpointing) lives in compiled, statically-typed code — never in an LLM.

--- a/examples/wrap-your-agent/README.md
+++ b/examples/wrap-your-agent/README.md
@@ -1,0 +1,100 @@
+# wrap-your-agent — put your loop under RiskKernel
+
+The smallest possible governed run: a plain Python `while` loop that would spin
+forever, wrapped so RiskKernel's **deterministic governor hard-stops it at a loop
+budget**. The kill comes from the Go core, not from the script.
+
+**No API key, no model call.** The loop budget is enforced in the daemon before
+each iteration, so you can watch the governor stop a runaway agent with nothing
+running but `riskkernel serve`. It's the loop-killer reduced to its essence — and
+the starting point for putting your *own* agent under governance.
+
+## Run it in 60 seconds
+
+```bash
+# 1. start the daemon — no key needed for this demo (the loop cap is enforced
+#    without any model call). Docker, or `riskkernel serve` from a binary:
+docker run --rm -p 7070:7070 ghcr.io/prashar32/riskkernel:latest
+
+# 2. in another terminal, install the SDK and run the loop
+cd examples/wrap-your-agent
+pip install -r requirements.txt        # the RiskKernel SDK (stdlib-only)
+python agent.py                        # watch the governor cap the loop
+```
+
+## What you'll see
+
+A real run (the run-id varies; the structure is the point):
+
+```
+▶ wrap-your-agent   loop budget = 8   (enforced by the Go governor)
+  run id: f6339d2b-07db-4e4e-b7de-d4754163d759
+
+  step  1 │ working… (your model / tool call goes here)
+  step  2 │ working… (your model / tool call goes here)
+  step  3 │ working… (your model / tool call goes here)
+  step  4 │ working… (your model / tool call goes here)
+  step  5 │ working… (your model / tool call goes here)
+  step  6 │ working… (your model / tool call goes here)
+  step  7 │ working… (your model / tool call goes here)
+  step  8 │ working… (your model / tool call goes here)
+
+🛑 RiskKernel halted the run — reason: loop_budget_exceeded
+   ── final ledger (enforced by the governor) ──
+     steps (loops) :    8   (budget: 8)
+     run id        : f6339d2b-07db-4e4e-b7de-d4754163d759
+   The loop would have run forever; the governor capped it — deterministically,
+   before the next iteration, with no LLM in the decision.
+```
+
+The 9th `run.step()` never returns: the daemon refuses it with HTTP
+`402 loop_budget_exceeded`, which the SDK raises as `rk.BudgetExceeded`. The script
+never decides to stop — the governor does.
+
+## Wrapping your own agent
+
+Putting an existing loop under governance is three lines around the loop you
+already have:
+
+```python
+import riskkernel as rk
+
+rt = rk.Runtime()                                       # points at http://localhost:7070
+with rt.governed_run(budget=rt.budget(loops=50, dollars=5, seconds=600)) as run:
+    while not done:
+        run.step()                                      # raises rk.BudgetExceeded at the cap
+        ...                                             # your existing reasoning + tool calls
+```
+
+`budget=` takes any mix of `loops`, `dollars`, `tokens`, `seconds` — the first to
+trip halts the run (see [the budget contract](../../docs/BUDGETS.md)). This example
+caps **loops** because that needs no key. To meter **dollars and tokens** too,
+route your model client through the run's proxy so every call is priced and
+counted under the same budget:
+
+```python
+cfg = run.proxy_config()
+#   cfg["base_url"] -> http://localhost:7070/v1   (point your OpenAI/Anthropic client here)
+#   cfg["headers"]  -> {"X-RiskKernel-Run-Id": run.id}
+```
+
+Prefer a decorator? `@rk.governed_run(budget=rk.Budget(loops=50))` wraps a whole
+function as one governed run, and `rk.current_run()` fetches the run inside it.
+
+## Tuning for a recording
+
+All knobs are constants at the top of `agent.py`:
+
+- `LOOP_BUDGET` (default `8`) — lower it for a faster kill, raise it for more
+  steps before the halt.
+- `WORK_SECONDS` — the simulated per-iteration delay; set `0` for an instant run.
+
+Nothing about the kill is faked: lower the budget and it halts sooner; remove the
+budget entirely and the `while True` really would run forever. The halt is always
+the real governor returning HTTP `402` from the daemon.
+
+## Want a real model in the loop?
+
+This example stays key-free to isolate the loop budget. For the same agent making
+**real model calls** through the proxy — with the dollar ledger climbing each step
+until the governor kills it — see [`examples/codebase-qa`](../codebase-qa).

--- a/examples/wrap-your-agent/agent.py
+++ b/examples/wrap-your-agent/agent.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""wrap-your-agent — put an existing Python agent loop under RiskKernel.
+
+The smallest possible governed run: a plain Python ``while`` loop that would spin
+forever, wrapped so RiskKernel's deterministic governor hard-stops it at a loop
+budget. The kill comes from the Go core (the daemon), not from this script.
+
+No API key, no model call. The loop budget is enforced in the daemon before each
+iteration, so you can watch the governor stop a runaway agent with nothing running
+but ``riskkernel serve``. It's the loop-killer reduced to its essence — and the
+starting point for putting your *own* agent under governance. (Add real model
+calls, and dollar/token budgets, via ``run.proxy_config()`` — see the README.)
+
+Run it:
+    riskkernel serve            # in another terminal — no key needed for this demo
+    python agent.py             # the governor caps the loop and halts the run
+
+The governance bits are exactly three calls: ``rt.governed_run(budget=...)`` to
+open the run, ``run.step()`` at the top of each iteration, and catching
+``rk.BudgetExceeded`` when the governor refuses the next step.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import riskkernel as rk
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Knobs — tune for a clean recording. Nothing here fakes the kill: the governor
+# (inside the daemon) does the enforcing, deterministically, before each step.
+# ─────────────────────────────────────────────────────────────────────────────
+DAEMON_URL = os.environ.get("RISKKERNEL_BASE_URL", "http://localhost:7070")
+LOOP_BUDGET = 8        # max loop iterations the governor will allow for the run
+WORK_SECONDS = 0.25    # simulated "thinking" / tool time per iteration (0 = instant)
+
+
+def do_one_step(step: int) -> None:
+    """Stand-in for your real per-iteration work — an LLM call, a tool call, a
+    retrieval. Here it only prints and sleeps, so the demo needs no API key."""
+    time.sleep(WORK_SECONDS)
+    print(f"  step {step:>2} │ working… (your model / tool call goes here)")
+
+
+def main() -> int:
+    rt = rk.Runtime(base_url=DAEMON_URL)
+    print(f"▶ wrap-your-agent   loop budget = {LOOP_BUDGET}   (enforced by the Go governor)")
+
+    try:
+        # 1) open a governed run with a hard budget …
+        with rt.governed_run(name="wrap-your-agent",
+                             budget=rt.budget(loops=LOOP_BUDGET)) as run:
+            print(f"  run id: {run.id}\n")
+            step = 0
+            while True:                       # a deliberately runaway agent loop
+                try:
+                    run.step()                # 2) … and call step() before each iteration
+                except rk.BudgetExceeded as halt:
+                    _report_halt(run, halt)   # 3) the governor refused the next step
+                    return 0
+                step += 1
+                do_one_step(step)
+    except rk.APIError as e:
+        if e.code == "connection_error":
+            print(f"\n✗ can't reach the daemon at {DAEMON_URL} — start it first:")
+            print("    riskkernel serve")
+            print("    # or: docker run --rm -p 7070:7070 ghcr.io/prashar32/riskkernel:latest")
+            return 1
+        raise
+
+
+def _report_halt(run: rk.Run, halt: rk.BudgetExceeded) -> None:
+    """Print the final, governor-enforced ledger for the halted run."""
+    usage = run.status().get("usage", {})
+    print(f"\n🛑 RiskKernel halted the run — reason: {halt.reason}")
+    print("   ── final ledger (enforced by the governor) ──")
+    print(f"     steps (loops) : {usage.get('loops', 0):>4}   (budget: {LOOP_BUDGET})")
+    print(f"     run id        : {run.id}")
+    print("   The loop would have run forever; the governor capped it — deterministically,")
+    print("   before the next iteration, with no LLM in the decision.")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/wrap-your-agent/requirements.txt
+++ b/examples/wrap-your-agent/requirements.txt
@@ -1,0 +1,8 @@
+# The only dependency is the RiskKernel Python SDK (stdlib-only itself — this demo
+# makes no model call at all). It isn't on PyPI yet, so it's installed from source.
+# This direct reference works from ANY directory (a bare relative path would resolve
+# against your CWD, not this file, which is brittle):
+riskkernel @ git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python
+
+# Working inside a clone and want your local SDK instead? From THIS directory:
+#     pip install ../../sdks/python


### PR DESCRIPTION
## What

A minimal, **no-key** example of putting an existing Python loop under RiskKernel — `examples/wrap-your-agent/`.

It is the loop-killer reduced to its essence: a deliberately runaway `while True` loop, wrapped in a governed run, that the deterministic governor hard-stops at a loop budget. Three governance calls — `rt.governed_run(budget=...)`, `run.step()` per iteration, and catching `rk.BudgetExceeded` — around a loop you already have.

```
🛑 RiskKernel halted the run — reason: loop_budget_exceeded
   ── final ledger (enforced by the governor) ──
     steps (loops) :    8   (budget: 8)
```

## Why this one, when codebase-qa exists

`codebase-qa` is the real-model, dollar-ledger demo — it needs an `ANTHROPIC_API_KEY`. This example deliberately makes **no model call at all**: the loop budget is enforced in the Go core before each iteration, so a first-time user sees the deterministic kill with nothing running but `riskkernel serve`. That is the lowest-friction possible "see it work" — exactly what the SDK on-ramp needs. The README points to `proxy_config()` and codebase-qa for adding real dollar/token metering.

## Contents

- `agent.py` — the governed loop (key-free; the kill is the daemon returning 402, surfaced as `rk.BudgetExceeded`). Handles "daemon not running" with a clear hint.
- `README.md` — run-in-60s, the real captured output, and a "wrap your own agent in three lines" section.
- `requirements.txt` — the SDK from source (same robust git+https reference as codebase-qa).
- Linked from the main README as the simplest SDK on-ramp.

## Verification

Ran against a local daemon started with no key: prints steps 1–8, then halts at `loop_budget_exceeded` with `loops=8` (exit 0). The daemon-down path prints the start-it-first hint (exit 1). `python -m py_compile` clean.