### PR TITLE
feat(pricing): config-updatable token→$ rates via RISKKERNEL_PRICING_FILE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ RISKKERNEL_DEFAULT_DOLLARS=
 RISKKERNEL_DEFAULT_LOOPS=
 RISKKERNEL_DEFAULT_SECONDS=
 
+# Optional token→$ pricing overrides (the dollar budget's basis), as a JSON file:
+#   { "claude-sonnet-4": { "inputPerM": 3.0, "outputPerM": 15.0 } }
+# Layers on the built-in list prices; the daemon refuses to start on a bad file.
+RISKKERNEL_PRICING_FILE=
+
 # OpenTelemetry export (Surface 3). Disabled unless an endpoint is set; spans go
 # ONLY to the endpoint you choose. Standard OTEL_* env vars.
 OTEL_EXPORTER_OTLP_ENDPOINT=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 - **`docs/BUDGETS.md`** — the budget surface (cost/loop/time/tokens) defined in
   one place as a public contract: the four dimensions, where they can be set,
   precedence, halt semantics, and the stability promise.
+- **Updatable token→$ pricing.** Point `RISKKERNEL_PRICING_FILE` at a JSON file of
+  `{ model: { inputPerM, outputPerM } }` to override the built-in list prices or
+  add models — the dollar budget's basis, kept current as providers change pricing
+  without recompiling. Overrides layer on the defaults; the daemon refuses to start
+  on a malformed, unknown-field, or negative-rate file. See
+  [`docs/BUDGETS.md`](docs/BUDGETS.md#pricing--the-dollar-budgets-basis).
 
 ### Changed
 - **Safe default budgets out of the box.** A daemon started with *no*

--- a/docs/BUDGETS.md
+++ b/docs/BUDGETS.md
@@ -123,6 +123,35 @@ per call is priced from provider-reported usage via the pricing table
 (config-updatable — provider pricing drifts), so a single in-flight call can
 land at, but never be issued past, the ceiling.
 
+## Pricing — the dollar budget's basis
+
+A call's cost is computed deterministically from **provider-reported token usage**
+times a per-model rate — no LLM is ever asked what something costs. RiskKernel ships
+built-in list prices (USD per 1M tokens) for the native providers, matched by
+**longest case-insensitive model-name prefix**, so dated snapshots
+(`claude-sonnet-4-5-20250101`) resolve to their family rate.
+
+Provider pricing drifts, and you may run models RiskKernel doesn't know. Point
+`RISKKERNEL_PRICING_FILE` at a JSON file to override built-in rates or add models —
+it layers on top of the defaults:
+
+```json
+{
+  "claude-sonnet-4":     { "inputPerM": 3.0, "outputPerM": 15.0 },
+  "my-finetuned-model":  { "inputPerM": 0.5, "outputPerM": 1.0 }
+}
+```
+
+Keys are model names or prefixes; rates are USD per 1,000,000 tokens. The daemon
+**refuses to start** on a missing, malformed, unknown-field, or negative-rate file
+— pricing affects money, so a typo must fail loudly rather than silently price a
+model at $0 — and logs how many overrides it loaded.
+
+A model with **no** rate (built-in or override) is priced at $0 and recorded with
+`priced: false` in the ledger: its tokens still count toward the *token* budget, but
+it cannot count toward the *dollar* budget. Add it to the pricing file to close that
+gap (`riskkernel audit export <run-id>` shows the per-call `priced` flag).
+
 ## Stability promise
 
 The following are stable per [`COMPATIBILITY.md`](../COMPATIBILITY.md) across
@@ -136,7 +165,9 @@ all v0.x minor versions:
 - HTTP 402 as the budget-halt status and the `HaltReason` enum values above
   (values may be *added*, never renamed or removed within a major version).
 - SDK: `Budget`, `governed_run(budget=...)`, `run.step()`, `BudgetExceeded`.
+- `RISKKERNEL_PRICING_FILE` and its `{ model: { inputPerM, outputPerM } }` format.
 
-The *safe default values* ($5 / 100 loops / 1h) are sane-default policy, not
-contract: they may be tuned in a minor release (with a CHANGELOG entry), since
-anyone depending on exact limits should set them explicitly.
+The *safe default values* ($5 / 100 loops / 1h) and the *built-in model rates* are
+sane-default policy, not contract: they may be tuned in a minor release (with a
+CHANGELOG entry), since anyone depending on exact limits or prices should set them
+explicitly (an explicit budget, or a `RISKKERNEL_PRICING_FILE`).

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -69,6 +69,18 @@ func Build(cfg *config.Config) (*Deps, error) {
 		return nil, err
 	}
 
+	// Load any token→$ pricing overrides before acquiring resources, so a bad
+	// pricing file fails fast. Pricing is the dollar budget's basis — refuse to
+	// start on a malformed file rather than silently misprice.
+	var priceOverrides map[string]pricing.Rate
+	if cfg.PricingFile != "" {
+		priceOverrides, err = pricing.LoadOverrides(cfg.PricingFile)
+		if err != nil {
+			return nil, fmt.Errorf("loading pricing overrides: %w", err)
+		}
+		log.Info("pricing overrides loaded", "file", cfg.PricingFile, "models", len(priceOverrides))
+	}
+
 	store, err := OpenStore(cfg, log)
 	if err != nil {
 		return nil, err
@@ -80,7 +92,7 @@ func Build(cfg *config.Config) (*Deps, error) {
 		return nil, err
 	}
 
-	prices := pricing.NewTable(nil)
+	prices := pricing.NewTable(priceOverrides)
 	if cfg.DefaultBudget.Defaulted {
 		log.Warn("no default budget configured — applying safe defaults",
 			"dollars", cfg.DefaultBudget.Dollars,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,12 @@ type Config struct {
 	// applied instead (see SafeDefault*) and Defaulted is true.
 	DefaultBudget BudgetConfig
 
+	// PricingFile is an optional JSON file of model→rate overrides for the token→$
+	// table — the dollar budget's basis. It lets prices stay current as providers
+	// change them without recompiling. Empty uses the built-in list prices only.
+	// Read from RISKKERNEL_PRICING_FILE.
+	PricingFile string
+
 	// OTel configures OpenTelemetry GenAI span export (Surface 3). Disabled unless
 	// an endpoint is set — RiskKernel never emits telemetry unless the user points
 	// it at their own OTLP backend.
@@ -173,6 +179,7 @@ func Load() (*Config, error) {
 		AnthropicAPIKey: os.Getenv("ANTHROPIC_API_KEY"),
 		OpenAIAPIKey:    os.Getenv("OPENAI_API_KEY"),
 		DefaultBudget:   budget,
+		PricingFile:     os.Getenv("RISKKERNEL_PRICING_FILE"),
 		OTel:            loadOTel(),
 		Approval: ApprovalConfig{
 			DefaultSafe: envBoolDefault("RISKKERNEL_APPROVAL_DEFAULT_SAFE", true),

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -4,12 +4,19 @@
 // config — RiskKernel never asks an LLM what something costs.
 package pricing
 
-import "strings"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
 
-// Rate is a model's price in USD per 1,000,000 tokens.
+// Rate is a model's price in USD per 1,000,000 tokens. The JSON tags are the
+// pricing-override file format (see LoadOverrides).
 type Rate struct {
-	InputPerM  float64
-	OutputPerM float64
+	InputPerM  float64 `json:"inputPerM"`
+	OutputPerM float64 `json:"outputPerM"`
 }
 
 // defaultRates holds built-in list prices. Matching is by case-insensitive prefix
@@ -45,6 +52,38 @@ func NewTable(overrides map[string]Rate) *Table {
 		m[strings.ToLower(k)] = v
 	}
 	return &Table{rates: m}
+}
+
+// LoadOverrides reads model→Rate overrides from a JSON file — the hook for keeping
+// prices current as providers change them, without recompiling. The format is a
+// map of model name (or prefix) to its rate in USD per 1M tokens:
+//
+//	{
+//	  "claude-sonnet-4": { "inputPerM": 3.0, "outputPerM": 15.0 },
+//	  "my-finetuned-model": { "inputPerM": 0.5, "outputPerM": 1.0 }
+//	}
+//
+// These layer on top of the built-in list prices (pass the result to NewTable).
+// A missing, unreadable, malformed, or negative-rate file is an error: pricing is
+// the dollar budget's basis, so the daemon refuses to start rather than silently
+// misprice.
+func LoadOverrides(path string) (map[string]Rate, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	overrides := make(map[string]Rate)
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&overrides); err != nil {
+		return nil, fmt.Errorf("parsing pricing file %s: %w", path, err)
+	}
+	for model, r := range overrides {
+		if r.InputPerM < 0 || r.OutputPerM < 0 {
+			return nil, fmt.Errorf("pricing file %s: model %q has a negative rate (%+v)", path, model, r)
+		}
+	}
+	return overrides, nil
 }
 
 // Rate returns the rate for a model and whether it was found. Matching is by

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -2,10 +2,21 @@ package pricing
 
 import (
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
 func approx(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+func writeTempPricing(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "pricing.json")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
 
 func TestCost_KnownModel(t *testing.T) {
 	tbl := NewTable(nil)
@@ -57,5 +68,57 @@ func TestCost_ZeroValueTableUsesDefaults(t *testing.T) {
 	usd, ok := tbl.Cost("gpt-4o-mini", 1_000_000, 0)
 	if !ok || !approx(usd, 0.15) {
 		t.Fatalf("zero-value table cost = %v ok=%v, want 0.15", usd, ok)
+	}
+}
+
+func TestLoadOverrides_AppliedToCost(t *testing.T) {
+	p := writeTempPricing(t, `{"claude-sonnet-4": {"inputPerM": 1.0, "outputPerM": 2.0}}`)
+	ov, err := LoadOverrides(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tbl := NewTable(ov)
+	usd, ok := tbl.Cost("claude-sonnet-4-5", 1_000_000, 1_000_000) // 1.0 + 2.0
+	if !ok || !approx(usd, 3.0) {
+		t.Fatalf("overridden cost = %v ok=%v, want 3.0", usd, ok)
+	}
+}
+
+func TestLoadOverrides_AddsNewModel(t *testing.T) {
+	// A model the built-ins don't know, priced via the override file (prefix match).
+	p := writeTempPricing(t, `{"my-finetune": {"inputPerM": 0.5, "outputPerM": 1.0}}`)
+	ov, err := LoadOverrides(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	usd, ok := NewTable(ov).Cost("my-finetune-v2", 1_000_000, 0)
+	if !ok || !approx(usd, 0.5) {
+		t.Fatalf("new-model cost = %v ok=%v, want 0.5", usd, ok)
+	}
+}
+
+func TestLoadOverrides_Malformed(t *testing.T) {
+	if _, err := LoadOverrides(writeTempPricing(t, `{not valid json`)); err == nil {
+		t.Fatal("malformed JSON should error")
+	}
+}
+
+func TestLoadOverrides_UnknownFieldRejected(t *testing.T) {
+	// A typo'd rate field must fail loudly — otherwise the model would silently
+	// price to $0 and slip past the dollar budget.
+	if _, err := LoadOverrides(writeTempPricing(t, `{"m": {"input_per_m": 3.0}}`)); err == nil {
+		t.Fatal("unknown rate field should error")
+	}
+}
+
+func TestLoadOverrides_NegativeRateRejected(t *testing.T) {
+	if _, err := LoadOverrides(writeTempPricing(t, `{"m": {"inputPerM": -1.0, "outputPerM": 2.0}}`)); err == nil {
+		t.Fatal("negative rate should error")
+	}
+}
+
+func TestLoadOverrides_MissingFile(t *testing.T) {
+	if _, err := LoadOverrides(filepath.Join(t.TempDir(), "nope.json")); err == nil {
+		t.Fatal("missing file should error")
 	}
 }


### PR DESCRIPTION
## Why

The **dollar budget** is only as accurate as the token→$ table behind it, and provider prices drift. The pricing table already supported overrides (`NewTable(overrides)`, even unit-tested) — but **nothing supplied them**: `bootstrap.go` passed `nil`, so the built-in list prices were the only rates a self-hosted user could ever get. Correcting a price or pricing a model RiskKernel doesn't know required recompiling. (CLAUDE.md §10 / the risk register both call for config-updatable pricing.)

## What

Point `RISKKERNEL_PRICING_FILE` at a JSON file of `{ model: { inputPerM, outputPerM } }`; it layers on top of the built-in rates.

```json
{
  "claude-sonnet-4":    { "inputPerM": 3.0, "outputPerM": 15.0 },
  "my-finetuned-model": { "inputPerM": 0.5, "outputPerM": 1.0 }
}
```

Pricing affects money, so the daemon **refuses to start** on a missing, malformed, **unknown-field** (a typo like `input_per_m` would otherwise silently price the model at $0), or negative-rate file — and logs how many overrides it loaded.

## Tests + docs

- `pricing_test.go`: load → cost (override applied; new model added by prefix) and every rejection path (malformed / unknown-field / negative / missing).
- `docs/BUDGETS.md`: a new **Pricing** section (how token→$ works, the override format, and the unpriced-model behavior — `priced: false`, counts toward the token budget but not the dollar budget), plus the file added to the stability promise.
- `.env.example` + `CHANGELOG.md` updated.

## Verification

- Full Go suite + gofmt + vet pass.
- End-to-end: daemon started with a valid file logs `pricing overrides loaded … models=2`; started with a typo'd-field file it refuses to boot — `error: loading pricing overrides: … json: unknown field "input_per_m"`.