### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-04
+
+A frictionless-adoption release: a one-line CLI install, three runnable key-free
+examples, safe default budgets out of the box, config-updatable model pricing, and
+a fix that makes LangChain budget enforcement actually stop the chain. No breaking
+API changes; forward-compatible with existing v0.1.x state.
+
 ### Added
 - **`tool_calls` audit trail is now readable** — `GET /v1/runs/{id}/tool-calls`,
   `riskkernel audit tools <run-id>`, and a `tool_calls` array in `audit export`
@@ -23,6 +30,13 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
   without recompiling. Overrides layer on the defaults; the daemon refuses to start
   on a malformed, unknown-field, or negative-rate file. See
   [`docs/BUDGETS.md`](docs/BUDGETS.md#pricing--the-dollar-budgets-basis).
+- **Runnable, key-free examples.** `examples/wrap-your-agent` (a generic governed
+  Python loop), `examples/langchain` (a LangChain agent capped at its loop budget),
+  and `examples/mcp` (the MCP gateway's allowlist, approval gate, and audit trail) —
+  each runs with nothing but the daemon, no API key.
+- **One-line CLI install.** `go install github.com/prashar32/riskkernel/cmd/riskkernel@latest`
+  needs no clone; the SDK's install-from-source command is documented (a PyPI
+  publish is still pending).
 
 ### Changed
 - **Safe default budgets out of the box.** A daemon started with *no*
@@ -33,6 +47,14 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
   *Behavior change:* setting any `RISKKERNEL_DEFAULT_*` variable (even to `0`,
   meaning unlimited) is explicit control and disables the safe defaults
   entirely — explicit configuration is always respected as-is.
+
+### Fixed
+- **LangChain budget halts now actually stop the chain.** The callback handler
+  raised `BudgetExceeded` / `ApprovalDenied` from its hooks, but LangChain swallows
+  exceptions thrown inside a callback unless the handler sets `raise_error=True` — so
+  on a real LangChain agent the halt was silently dropped and the run kept spending
+  past budget. The handler now propagates the halt; the OpenAI Agents adapter was
+  audited for the same flaw (it propagates correctly) and has regression tests.
 
 ## [0.1.2] - 2026-06-01
 
@@ -167,7 +189,8 @@ and a memory you own, in one self-hosted binary. Three integration surfaces
   (keyless) on each `v*` tag; GoReleaser binaries + checksums + GitHub release;
   `govulncheck` + CodeQL in CI. One-line `docker run` quickstart.
 
-[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/prashar32/riskkernel/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/prashar32/riskkernel/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/prashar32/riskkernel/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/prashar32/riskkernel/releases/tag/v0.1.0

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -71,7 +71,7 @@ orchestration inside the runtime, and a required heavyweight datastore.
 
 ## Status & roadmap
 
-v0.1.2 (released). The runtime is the entire current focus. See
+v0.2.0 (released). The runtime is the entire current focus. See
 [`CHANGELOG.md`](../CHANGELOG.md) for what has landed and the public contract in
 [`api/v1/`](../api/v1) for the stable surface SDKs build on.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ package version
 // These are set via -ldflags "-X github.com/prashar32/riskkernel/internal/version.Version=..."
 var (
 	// Version is the semantic version of this build.
-	Version = "0.1.3-dev"
+	Version = "0.2.1-dev"
 	// Commit is the git commit this binary was built from.
 	Commit = "unknown"
 	// Date is the build date (RFC3339), stamped at release.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "riskkernel"
-version = "0.1.2"
+version = "0.2.0"
 description = "Thin Python client for the RiskKernel reliability runtime (Surface 2)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdks/python/riskkernel/__init__.py
+++ b/sdks/python/riskkernel/__init__.py
@@ -37,7 +37,7 @@ from .runtime import (
     governed_run,
 )
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"
 
 __all__ = [
     "RiskKernel",


### PR DESCRIPTION
## v0.2.0 — week-1 frictionless-adoption release

Rolls up everything merged since v0.1.2 (#50–#59) and bumps the version markers per the release checklist.

**Highlights**
- **One-line CLI install** — `go install …/cmd/riskkernel@latest`, no clone.
- **Three runnable, key-free examples** — `wrap-your-agent`, `langchain`, `mcp`.
- **Safe default budgets** out of the box ($5 / 100 loops / 1h) — a default-behavior change.
- **Config-updatable model pricing** — `RISKKERNEL_PRICING_FILE`.
- **Fix:** LangChain budget halts now actually stop the chain (`raise_error`); the OpenAI Agents adapter was audited (clean) and got regression tests.

No breaking API changes; forward-compatible with existing v0.1.x state.

**Checklist files bumped (§13)**
- `CHANGELOG.md` — `[Unreleased]` rolled into `## [0.2.0] - 2026-06-04` (+ backfilled the examples / install / LangChain-fix entries that earlier PRs missed); compare links updated; fresh empty `[Unreleased]`.
- SDK → `0.2.0` (`pyproject.toml` + `__init__.py`); `version.go` default → `0.2.1-dev`; `docs/VISION.md` status line.

## After merge (the tag flow — do NOT skip the sync)

Per §13, tag the **merged** commit, not this branch:
```
git checkout main && git pull            # land the squash-merge first
git tag -a v0.2.0 -m "v0.2.0"            # → release workflow builds + cosign-signs the image
git push origin v0.2.0
```
Skipping the pull lands the tag on the previous commit and ships stale version markers (this bit v0.1.1). Verify before pushing: `git show v0.2.0:sdks/python/pyproject.toml` reads `0.2.0`. Then verify the image: `docker run ghcr.io/prashar32/riskkernel:0.2.0 version`.