### PR TITLE
fix(runs): exact-once resume across a mid-step crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
   finishes without re-spending; `./demo.sh` scripts the whole crash-and-recover and
   proves the loop counter doesn't double. Key-free.
 
+### Fixed
+- **Resume is exact-once across a mid-step crash.** If the daemon died after a step
+  was counted (`BeginStep`) but before that step's checkpoint, the run row was left
+  one step ahead of the last durable snapshot — so resume re-attempted the step and
+  the loop budget counted it twice. The daemon now reloads each run from its last
+  checkpoint, rolling that partial step back so it's counted exactly once. (The
+  dollar budget was already exact — a partial step records no cost.)
+
 ## [0.2.0] - 2026-06-04
 
 A frictionless-adoption release: a one-line CLI install, three runnable key-free

--- a/internal/runs/manager.go
+++ b/internal/runs/manager.go
@@ -325,7 +325,7 @@ func (m *Manager) Reload(ctx context.Context) (int, error) {
 		if _, ok := m.runs[rec.ID]; ok {
 			continue
 		}
-		m.runs[rec.ID] = m.reloadRun(rec)
+		m.runs[rec.ID] = m.reloadRun(ctx, rec)
 		n++
 	}
 	return n, nil
@@ -333,7 +333,13 @@ func (m *Manager) Reload(ctx context.Context) (int, error) {
 
 // reloadRun reconstructs a live Run from a persisted record, seeding the governor
 // with the run's prior usage so budget enforcement continues across the restart.
-func (m *Manager) reloadRun(rec storage.RunRecord) *Run {
+//
+// It resumes from the last DURABLE checkpoint rather than the live run row. A step
+// that was counted (BeginStep persists the run row) but whose work crashed before
+// its checkpoint leaves the row one step ahead of the last consistent snapshot;
+// restoring from the checkpoint rolls that partial step back, so the resumed agent
+// re-attempts it exactly once — no double-count of the loop or dollar budget.
+func (m *Manager) reloadRun(ctx context.Context, rec storage.RunRecord) *Run {
 	budget := governor.Budget{
 		Tokens: rec.BudgetTokens, Dollars: rec.BudgetDollars,
 		Loops: rec.BudgetLoops, Seconds: rec.BudgetSeconds,
@@ -344,7 +350,17 @@ func (m *Manager) reloadRun(rec storage.RunRecord) *Run {
 		Dollars:          rec.UsageDollars,
 		Loops:            rec.UsageLoops,
 	}
-	return &Run{
+	rolledBack := false
+	if cp, err := m.store.LatestCheckpoint(ctx, rec.ID); err == nil && cp.UsageLoops < rec.UsageLoops {
+		usage = governor.Usage{
+			PromptTokens:     cp.UsagePromptTokens,
+			CompletionTokens: cp.UsageCompletionTokens,
+			Dollars:          cp.UsageDollars,
+			Loops:            cp.UsageLoops,
+		}
+		rolledBack = true
+	}
+	r := &Run{
 		ID:        rec.ID,
 		Name:      rec.Name,
 		Budget:    budget,
@@ -354,6 +370,12 @@ func (m *Manager) reloadRun(rec storage.RunRecord) *Run {
 		createdAt: rec.CreatedAt,
 		updatedAt: rec.UpdatedAt,
 	}
+	if rolledBack {
+		// Make the persisted row agree with the rolled-back governor, so
+		// `runs list` / GET don't keep showing the discarded partial step.
+		m.persistRun(r)
+	}
+	return r
 }
 
 // Checkpoint records a crash-resumable checkpoint for a run with an opaque

--- a/internal/runs/manager_test.go
+++ b/internal/runs/manager_test.go
@@ -170,6 +170,67 @@ func TestManager_ReloadSkipsTerminalRuns(t *testing.T) {
 	}
 }
 
+func TestManager_ReloadRollsBackPartialStep(t *testing.T) {
+	// A crash in the middle of a step (the loop was counted via BeginStep, but the
+	// step's checkpoint never landed) must not double-count that step on resume.
+	store, err := storage.OpenSQLite(filepath.Join(t.TempDir(), "partial.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	noop := slog.New(slog.NewTextHandler(noopWriter{}, nil))
+	ctx := context.Background()
+
+	// Process A: 2 steps, each checkpointed, then a 3rd step STARTS (row → loops 3)
+	// but crashes before its checkpoint (last checkpoint stays at loops 2).
+	mA := NewManager(governor.Budget{Loops: 5}).WithStore(store, noop)
+	rA := mA.Create(CreateOptions{ID: "partial", Name: "p"})
+	for i := 1; i <= 2; i++ {
+		if _, err := rA.BeginStep(); err != nil {
+			t.Fatalf("step %d: %v", i, err)
+		}
+		if err := mA.Checkpoint("partial", "", map[string]any{"cursor": i}); err != nil {
+			t.Fatalf("checkpoint %d: %v", i, err)
+		}
+	}
+	if _, err := rA.BeginStep(); err != nil { // the partial 3rd step — never checkpointed
+		t.Fatalf("partial step: %v", err)
+	}
+
+	// Sanity: the run row is one step ahead (3) of the last checkpoint (2).
+	got, _ := store.GetRun(ctx, "partial")
+	cp, _ := store.LatestCheckpoint(ctx, "partial")
+	if got.UsageLoops != 3 || cp.UsageLoops != 2 {
+		t.Fatalf("row loops=%d, checkpoint loops=%d; want 3 and 2", got.UsageLoops, cp.UsageLoops)
+	}
+
+	// --- crash + reload in a fresh manager ---
+	mB := NewManager(governor.Budget{}).WithStore(store, noop)
+	if n, err := mB.Reload(ctx); err != nil || n != 1 {
+		t.Fatalf("Reload = %d, %v; want 1", n, err)
+	}
+	rB, ok := mB.Get("partial")
+	if !ok {
+		t.Fatal("run not reloaded")
+	}
+
+	// The partial step is rolled back: the governor resumes at loops 2, not 3 …
+	if v := rB.View(); v.Usage.Loops != 2 {
+		t.Fatalf("resumed loops = %d, want 2 (partial step rolled back)", v.Usage.Loops)
+	}
+	// … and the persisted row was corrected to match.
+	if got, _ := store.GetRun(ctx, "partial"); got.UsageLoops != 2 {
+		t.Fatalf("persisted loops after reload = %d, want 2", got.UsageLoops)
+	}
+	// Re-attempting the 3rd step counts it exactly once → loops 3, not 4.
+	if _, err := rB.BeginStep(); err != nil {
+		t.Fatalf("re-attempt: %v", err)
+	}
+	if v := rB.View(); v.Usage.Loops != 3 {
+		t.Fatalf("after re-attempt loops = %d, want 3 (exactly once)", v.Usage.Loops)
+	}
+}
+
 func TestManager_HaltPersistsStatus(t *testing.T) {
 	store, err := storage.OpenSQLite(filepath.Join(t.TempDir(), "halt.db"))
 	if err != nil {


### PR DESCRIPTION
## The edge case (flagged by the kill-9-resume demo)

A step is counted in `BeginStep` — which persists the run row — *before* its work runs and checkpoints. If the daemon is `kill -9`’d in that window, the run row is left **one loop ahead** of the last durable checkpoint. On resume the agent re-attempts the step, and the loop budget counts it **twice**.

(The **dollar** budget was already exact — a partial step records no cost; cost is checkpointed atomically with the model call. So only the loop counter over-counted, by at most one per crash.)

## The fix

On `Reload`, reconstruct each run from its **last checkpoint** (the last consistent snapshot) instead of the live run row. That rolls the partial step back, so resume re-attempts it **exactly once**. The persisted row is corrected to match, so `runs list` / `GET` don’t keep showing the discarded step. No API change.

## Verified end-to-end (real `kill -9`)

```
BEFORE crash:      loops=3   (2 done + 1 partial)
AFTER  resume:     loops=2   (partial step rolled back)
AFTER  re-attempt: loops=3   (counted exactly once)
```

Plus `TestManager_ReloadRollsBackPartialStep` (drives a partial step, reloads in a fresh manager, asserts the rollback + the corrected row + exact-once re-attempt). Full Go suite + gofmt clean.

A docs/tutorial page on the full crash-resume model follows in a separate PR.