### PR TITLE
ci: publish the SDK to PyPI on release (trusted publishing)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,48 @@
+name: Publish Python SDK
+
+# Publishes the `riskkernel` SDK to PyPI on every version tag, so the install is the
+# clean, ordinary `pip install riskkernel` — no git URL, no #subdirectory.
+#
+# Auth is PyPI Trusted Publishing (OIDC): NO API token or password is stored
+# anywhere. One-time setup on PyPI (https://docs.pypi.org/trusted-publishers/):
+#   add a "pending publisher" for project `riskkernel` →
+#     Owner: prashar32   Repository: riskkernel
+#     Workflow: python-publish.yml   Environment: (leave blank)
+# PyPI claims the name on the first publish. The version in sdks/python/pyproject.toml
+# must match the tag (the release checklist bumps it).
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build & publish riskkernel to PyPI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/python
+    permissions:
+      id-token: write # OIDC for PyPI trusted publishing — no stored secret
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Don't publish a broken SDK: the suite is stdlib-only, no install needed.
+      - name: Test
+        run: python -m unittest discover -s tests -t . -v
+
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: sdks/python/dist/
+          skip-existing: true


### PR DESCRIPTION
## Why

The from-source install is clunky:

```bash
pip install "git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python"
```

…only because the SDK lives in a monorepo subdirectory, so pip finds no `pyproject.toml` at the repo root. Publishing to PyPI makes it the ordinary `pip install riskkernel` — no git URL, no `#subdirectory`, like any other package.

## What

A workflow that builds and publishes the `riskkernel` SDK to PyPI on every version tag, via **PyPI Trusted Publishing (OIDC)** — **no API token or password is stored anywhere**. It runs the (stdlib-only) tests, builds an sdist + wheel, and uploads; `skip-existing` guards re-runs.

## One-time setup (PyPI side, mine to do)

The name `riskkernel` is free on PyPI. Add a *pending* trusted publisher for it (PyPI → your account → Publishing):

- Project: `riskkernel` · Owner: `prashar32` · Repository: `riskkernel`
- Workflow: `python-publish.yml` · Environment: *(blank)*

PyPI claims the name on the first publish. After that, tagging a release publishes the SDK alongside the binaries + image, and the install docs move to `pip install riskkernel`.

## Verified

- The SDK builds a clean wheel + sdist, and the wheel contains all 9 package files (the empty-wheel monorepo bug from #32 stays fixed via `ignore-vcs`).
- Workflow YAML validated.