### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-06
+
+The crash-resume moat, proven and polished: a real `kill -9` → resume demo, the
+`resume_run` SDK entry point, exact-once budgets across a mid-step crash, and a
+crash-resume guide — plus a one-command `riskkernel init` on-ramp and a clean
+`pip install riskkernel`. No breaking API changes; forward-compatible with v0.2.x
+state.
+
 ### Added
+- **The SDK is on PyPI** — install it with the ordinary `pip install riskkernel`
+  (no git URL, no `#subdirectory`). Published on release via PyPI Trusted Publishing.
 - **`riskkernel init`** — scaffolds a working starting point in one command: a `.env`
   (provider key, default budget, the data dir where runs and crash-resume checkpoints
   live) and a runnable, key-free `quickstart.py` (a governed loop the budget stops),
@@ -215,7 +225,8 @@ and a memory you own, in one self-hosted binary. Three integration surfaces
   (keyless) on each `v*` tag; GoReleaser binaries + checksums + GitHub release;
   `govulncheck` + CodeQL in CI. One-line `docker run` quickstart.
 
-[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/prashar32/riskkernel/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/prashar32/riskkernel/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/prashar32/riskkernel/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/prashar32/riskkernel/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -98,11 +98,10 @@ riskkernel serve     # start the daemon (reads .env)
 ```
 
 (or `make build` from a clone). Deeper control (loops, checkpoints, approval
-gates) is the Python SDK — install it from source (PyPI publish is on the
-roadmap):
+gates) is the Python SDK:
 
 ```bash
-pip install "git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python"
+pip install riskkernel
 ```
 
 See [`sdks/python`](sdks/python). Trace every run in your own backend:

--- a/cmd/riskkernel/init.go
+++ b/cmd/riskkernel/init.go
@@ -55,7 +55,7 @@ func runInit(args []string) error {
 Next:
   1. (optional) put your ANTHROPIC_API_KEY in .env — model calls need it; the loop demo doesn't
   2. riskkernel serve                 # start the governance daemon (reads .env)
-  3. pip install "git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python"
+  3. pip install riskkernel
   4. python quickstart.py             # watch the governor stop a runaway loop
 `)
 	return nil

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -71,7 +71,7 @@ orchestration inside the runtime, and a required heavyweight datastore.
 
 ## Status & roadmap
 
-v0.2.0 (released). The runtime is the entire current focus. See
+v0.3.0 (released). The runtime is the entire current focus. See
 [`CHANGELOG.md`](../CHANGELOG.md) for what has landed and the public contract in
 [`api/v1/`](../api/v1) for the stable surface SDKs build on.
 

--- a/examples/codebase-qa/requirements.txt
+++ b/examples/codebase-qa/requirements.txt
@@ -1,8 +1,6 @@
-# The only dependency is the RiskKernel Python SDK (stdlib-only itself — the agent
-# uses urllib for the proxy call, no requests/httpx). It isn't on PyPI yet, so it's
-# installed from source. This direct reference works from ANY directory (pip
-# resolves a bare relative path against your CWD, not this file, which is brittle):
-riskkernel @ git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python
+# The only dependency is the RiskKernel Python SDK (stdlib-only — the agent uses
+# urllib for the proxy call, no requests/httpx).
+riskkernel
 
 # Working inside a clone and want your local SDK instead? From THIS directory:
 #     pip install ../../sdks/python

--- a/examples/kill-9-resume/requirements.txt
+++ b/examples/kill-9-resume/requirements.txt
@@ -1,6 +1,6 @@
-# The only dependency is the RiskKernel Python SDK (stdlib-only). It isn't on PyPI
-# yet, so it's installed from source. resume_run() needs SDK >= 0.2.0.
-riskkernel @ git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python
+# The only dependency is the RiskKernel Python SDK (stdlib-only). resume_run() needs
+# riskkernel >= 0.3.0.
+riskkernel>=0.3.0
 
 # Working inside a clone and want your local SDK instead? From THIS directory:
 #     pip install ../../sdks/python

--- a/examples/langchain/requirements.txt
+++ b/examples/langchain/requirements.txt
@@ -1,12 +1,8 @@
-# This LangChain example needs two things: langchain-core (the callback machinery
-# the adapter hooks into) and the RiskKernel Python SDK. The SDK isn't on PyPI yet,
-# so it's installed from source; its core is stdlib-only. The git+https reference
-# works from ANY directory (a bare relative path would resolve against your CWD).
-#
-# Tested with langchain-core 1.4.0; the adapter also supports the older
-# langchain.callbacks.base import path.
+# This LangChain example needs langchain-core (the callback machinery the adapter
+# hooks into) and the RiskKernel Python SDK (stdlib-only). Tested with langchain-core
+# 1.4.0; the adapter also supports the older langchain.callbacks.base import path.
 langchain-core>=0.2
-riskkernel @ git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python
+riskkernel
 
 # Working inside a clone and want your local SDK instead? From THIS directory:
 #     pip install ../../sdks/python

--- a/examples/wrap-your-agent/requirements.txt
+++ b/examples/wrap-your-agent/requirements.txt
@@ -1,8 +1,6 @@
-# The only dependency is the RiskKernel Python SDK (stdlib-only itself — this demo
-# makes no model call at all). It isn't on PyPI yet, so it's installed from source.
-# This direct reference works from ANY directory (a bare relative path would resolve
-# against your CWD, not this file, which is brittle):
-riskkernel @ git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python
+# The only dependency is the RiskKernel Python SDK (stdlib-only — this demo makes no
+# model call at all).
+riskkernel
 
 # Working inside a clone and want your local SDK instead? From THIS directory:
 #     pip install ../../sdks/python

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ package version
 // These are set via -ldflags "-X github.com/prashar32/riskkernel/internal/version.Version=..."
 var (
 	// Version is the semantic version of this build.
-	Version = "0.2.1-dev"
+	Version = "0.3.1-dev"
 	// Commit is the git commit this binary was built from.
 	Commit = "unknown"
 	// Date is the build date (RFC3339), stamped at release.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -8,8 +8,7 @@ SDK just makes governed runs ergonomic from Python. **Core install is stdlib-onl
 (no third-party dependencies).
 
 ```bash
-# Not on PyPI yet — install from source (the core is stdlib-only, so this is light):
-pip install "git+https://github.com/prashar32/riskkernel.git#subdirectory=sdks/python"
+pip install riskkernel
 ```
 
 ## Quickstart

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "riskkernel"
-version = "0.2.0"
+version = "0.3.0"
 description = "Thin Python client for the RiskKernel reliability runtime (Surface 2)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdks/python/riskkernel/__init__.py
+++ b/sdks/python/riskkernel/__init__.py
@@ -37,7 +37,7 @@ from .runtime import (
     governed_run,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "RiskKernel",


### PR DESCRIPTION
## v0.3.0

Rolls up everything merged since v0.2.0 (#61–#66) and makes the SDK install clean.

**Highlights**
- The crash-resumable moat, proven and polished — `resume_run`, the `kill -9` resume demo, **exact-once budgets across a mid-step crash**, and a crash-resume guide.
- **`riskkernel init`** — one-command on-ramp (`.env` + a runnable example).
- **The SDK is on PyPI** — `pip install riskkernel`, no git URL, no `#subdirectory`. Switched everywhere (README, the `init` template, example `requirements.txt`, SDK README).

No breaking API changes; forward-compatible with existing v0.2.x state.

**Checklist files bumped**
- `CHANGELOG.md` → `## [0.3.0] - 2026-06-06`, compare links, fresh empty `[Unreleased]`.
- SDK → `0.3.0` (`pyproject` + `__init__`); `version.go` → `0.3.1-dev`; `docs/VISION.md` status line.

## After merge — tag the *merged* commit (PyPI publishes on the tag)

The pending trusted publisher is configured, so the tag fires three things: binaries, the cosign-signed image, **and the PyPI publish**.

```bash
git checkout main && git pull            # land the squash first (do NOT skip)
git tag -a v0.3.0 -m "v0.3.0" && git push origin v0.3.0
```

Skipping the pull lands the tag on the previous commit and ships stale markers (it bit v0.1.1). Verify before pushing: `git show v0.3.0:sdks/python/pyproject.toml` reads `0.3.0`. Then, after the workflows finish: `pip install riskkernel` works, `docker run ghcr.io/prashar32/riskkernel:0.3.0 version`, and `cosign verify`.