### PR TITLE
ci: don't run the PR-review job on Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore(ci)"
+    # Batch CI Action bumps into one weekly PR instead of one per action — they're
+    # low-risk and easier to review and merge together.
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -22,9 +22,15 @@ permissions:
 
 jobs:
   review:
-    # Same-repo PRs only. On a fork PR head.repo.full_name differs from the repo,
-    # the secret is absent, and this job would always fail — so skip it there.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Same-repo, human-authored PRs only. On a fork PR head.repo.full_name differs
+    # from the repo; on a Dependabot PR the run gets a restricted token with no
+    # access to repo secrets. In both cases CLAUDE_CODE_OAUTH_TOKEN is absent and
+    # this job could only fail — so skip it (a clean skip, not a red X). Both are
+    # instead reviewed on demand: comment "@claude" (claude.yml runs in the base-repo
+    # context where the secret IS available).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The automated PR-review job already skips **fork** PRs — GitHub doesn't expose repo secrets to them, so `CLAUDE_CODE_OAUTH_TOKEN` is absent and the job can only fail. **Dependabot PRs hit the exact same wall** (restricted token, no secret access), but they're raised from a same-repo branch, so they slipped past the fork guard, ran, and failed every time — painting a red ✗ on dependency bumps whose real checks (build & test, CodeQL, govulncheck) all pass.

This:
- extends the `review` job's guard to also skip `dependabot[bot]` — a clean skip, not a failure (dependency PRs are still reviewable on demand via an `@claude` comment, which runs in the base-repo context where the secret exists);
- groups the weekly CI Action bumps into a single PR instead of one per action, so they're easier to review and merge together.

No effect on human-authored PRs — the review job runs on those exactly as before.