### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-07
+
+Observability, rounded out: tool-call governance now shows up in your traces, a
+ready-made Grafana + Tempo dashboard turns RiskKernel's spans into cost/halt/tool
+panels, and OTLP export can authenticate to backends that require it (Honeycomb,
+Grafana Cloud). No breaking API changes; forward-compatible with v0.3.x state.
+
 ### Added
 - **Tool governance shows up in your traces.** Every governed MCP `tools/call` now
   emits an OpenTelemetry span (`execute_tool {tool}`) alongside the model-call spans,
@@ -245,7 +252,8 @@ and a memory you own, in one self-hosted binary. Three integration surfaces
   (keyless) on each `v*` tag; GoReleaser binaries + checksums + GitHub release;
   `govulncheck` + CodeQL in CI. One-line `docker run` quickstart.
 
-[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/prashar32/riskkernel/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/prashar32/riskkernel/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/prashar32/riskkernel/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/prashar32/riskkernel/compare/v0.1.1...v0.1.2

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -71,7 +71,7 @@ orchestration inside the runtime, and a required heavyweight datastore.
 
 ## Status & roadmap
 
-v0.3.0 (released). The runtime is the entire current focus. See
+v0.4.0 (released). The runtime is the entire current focus. See
 [`CHANGELOG.md`](../CHANGELOG.md) for what has landed and the public contract in
 [`api/v1/`](../api/v1) for the stable surface SDKs build on.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ package version
 // These are set via -ldflags "-X github.com/prashar32/riskkernel/internal/version.Version=..."
 var (
 	// Version is the semantic version of this build.
-	Version = "0.3.1-dev"
+	Version = "0.4.1-dev"
 	// Commit is the git commit this binary was built from.
 	Commit = "unknown"
 	// Date is the build date (RFC3339), stamped at release.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "riskkernel"
-version = "0.3.0"
+version = "0.4.0"
 description = "Thin Python client for the RiskKernel reliability runtime (Surface 2)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdks/python/riskkernel/__init__.py
+++ b/sdks/python/riskkernel/__init__.py
@@ -37,7 +37,7 @@ from .runtime import (
     governed_run,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     "RiskKernel",


### PR DESCRIPTION
Cuts **v0.4.0** — the OTel observability release. Rolls in the work merged since v0.3.0:

- tool-call governance spans (#68)
- a provisioned Grafana + Tempo cost & governance dashboard (#75)
- authenticated OTLP export — `OTEL_EXPORTER_OTLP_HEADERS` (#76)

Version bumps per the release checklist: `CHANGELOG.md` (rolled `[Unreleased]` → `[0.4.0]`, fresh `[Unreleased]`, compare links), `docs/VISION.md` status line, the `internal/version` dev default (`0.4.1-dev`), and the Python SDK (`0.4.0` — SDK code is unchanged since v0.3.0, bumped for consistency). Forward-compatible with v0.3.x state.

Verified before tagging: full `go build` / `go vet` / `go test ./...` green (13 packages); SDK tests pass (14 passed, 2 skipped).

After this merges I'll sync `main` and tag `v0.4.0`, which triggers the signed multi-arch image + binaries.