### PR TITLE
chore(sdk): canonicalize the TS package repository URL

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -6,7 +6,7 @@
   "author": "Adarsh Prashar",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prashar32/riskkernel",
+    "url": "git+https://github.com/prashar32/riskkernel.git",
     "directory": "sdks/typescript"
   },
   "homepage": "https://github.com/prashar32/riskkernel",


### PR DESCRIPTION
Use the canonical `git+https://github.com/prashar32/riskkernel.git` form for `repository.url` in the TypeScript SDK's `package.json`, so `npm publish` stops auto-correcting it with a warning (`"repository.url" was normalized to …`). Metadata only — no code or build change.

`npm publish --dry-run` is now warning-free.