### PR TITLE
fix(runs): a halted run stays halted when its id is reused after a restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
   mock provider, and reports the spend saved straight from the cost ledger. Key-free
   and tunable: `python3 benchmark/benchmark.py`.
 
+### Fixed
+- **A halted run stays halted when its id is reused after a restart.** Reload
+  restores only *running* runs, so a proxy call that reused the run-id of a run that
+  had already halted (e.g. hit its dollar budget) was minting a fresh, default-budget
+  run for that id and returning `200` instead of `402` — the halt didn't survive the
+  restart. The proxy path (`GetOrCreate`) now consults the store on a cache miss and
+  restores an existing run as-is: a terminal run (budget halt or kill-switch cancel)
+  comes back terminal and keeps refusing work; only a genuinely new id gets a fresh
+  run.
+
 ## [0.4.0] - 2026-06-07
 
 Observability, rounded out: tool-call governance now shows up in your traces, a

--- a/internal/governor/governor.go
+++ b/internal/governor/governor.go
@@ -102,6 +102,19 @@ func WithRestoredUsage(u Usage) Option {
 	return func(r *Run) { r.usage = u }
 }
 
+// WithRestoredHalt reconstructs a run that had already halted before a restart,
+// so a reused run-id stays terminal — it refuses further work with its original
+// reason instead of resuming. Crash-resume restores in-flight runs with
+// WithRestoredUsage; this restores the ones that were already over, so a reused
+// id can't be handed a fresh budget. A HaltNone reason is a no-op. (#29)
+func WithRestoredHalt(reason HaltReason) Option {
+	return func(r *Run) {
+		if reason != HaltNone {
+			r.halted = reason
+		}
+	}
+}
+
 // New starts governing a run under budget b. The returned Run derives a Context
 // (from parent) that is cancelled on halt/cancel, and that additionally carries a
 // real-time deadline when a time budget is set — so an in-flight provider call is
@@ -122,6 +135,11 @@ func New(parent context.Context, b Budget, opts ...Option) *Run {
 		r.ctx, r.cancel = context.WithTimeout(parent, time.Duration(b.Seconds)*time.Second)
 	} else {
 		r.ctx, r.cancel = context.WithCancel(parent)
+	}
+	if r.halted != HaltNone {
+		// A run restored via WithRestoredHalt is already terminal: fire the kill
+		// switch so its Context is dead, matching a run that halted live.
+		r.cancel()
 	}
 	return r
 }

--- a/internal/governor/governor_test.go
+++ b/internal/governor/governor_test.go
@@ -231,6 +231,43 @@ func TestWithRestoredUsage(t *testing.T) {
 	asHalt(t, r.RecordUsage(200, 0, 0), HaltTokenBudget)
 }
 
+func TestWithRestoredHalt(t *testing.T) {
+	// A run reconstructed as already-halted stays terminal: it refuses all work
+	// with its original reason and its context is dead, regardless of budget. (#29)
+	r := New(context.Background(), Budget{Dollars: 5.0},
+		WithRestoredUsage(Usage{Dollars: 6.0}),
+		WithRestoredHalt(HaltDollarBudget))
+	defer r.Close()
+
+	if !r.Halted() {
+		t.Fatal("restored-halted run should report halted")
+	}
+	asHalt(t, r.CanProceed(), HaltDollarBudget)
+	asHalt(t, r.PreStep(), HaltDollarBudget)
+	asHalt(t, r.RecordUsage(1, 1, 0.01), HaltDollarBudget)
+	select {
+	case <-r.Context().Done():
+	default:
+		t.Fatal("a restored-halted run's context should be cancelled")
+	}
+
+	// A cancel-halted run keeps the cancelled reason even though usage is under the
+	// budget — re-deriving the halt from usage alone could not recover this.
+	c := New(context.Background(), Budget{Dollars: 5.0}, WithRestoredHalt(HaltCancelled))
+	defer c.Close()
+	asHalt(t, c.CanProceed(), HaltCancelled)
+
+	// HaltNone is a no-op: a genuinely running run is unaffected.
+	live := New(context.Background(), Budget{Dollars: 5.0}, WithRestoredHalt(HaltNone))
+	defer live.Close()
+	if live.Halted() {
+		t.Fatal("WithRestoredHalt(HaltNone) must not halt the run")
+	}
+	if err := live.CanProceed(); err != nil {
+		t.Fatalf("a running run should proceed: %v", err)
+	}
+}
+
 func TestConcurrentCancel(t *testing.T) {
 	r := New(context.Background(), Budget{Tokens: 1_000_000_000})
 	defer r.Close()

--- a/internal/runs/manager.go
+++ b/internal/runs/manager.go
@@ -12,6 +12,7 @@ package runs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -265,20 +266,53 @@ func (m *Manager) Get(rid string) (*Run, bool) {
 // GetOrCreate returns the run with the given id, lazily creating it under the
 // default budget if unknown. This is the proxy path: a client groups calls into a
 // run by sending a stable run-id header; the first call materializes the run.
+//
+// On a cache miss it first consults the store: a run with that id may already
+// exist there — e.g. one that halted before a restart (Reload restores only
+// running runs). Such a run is restored as-is, so a terminal/over-budget run stays
+// halted and keeps refusing work instead of being handed a fresh, default-budget
+// run for the reused id. Only a genuinely unknown id mints a new run. (#29)
 func (m *Manager) GetOrCreate(rid string) *Run {
 	if r, ok := m.Get(rid); ok {
 		return r
 	}
+	restored := m.restoreFromStore(rid) // store I/O without the manager lock; nil if unknown
+
 	m.mu.Lock()
 	if r, ok := m.runs[rid]; ok { // re-check under write lock
 		m.mu.Unlock()
+		if restored != nil {
+			restored.Close() // lost the race: release the discarded governor's context
+		}
 		return r
 	}
-	r := m.newRun(rid, "", m.defaultBudget, nil)
+	r := restored
+	if r == nil {
+		r = m.newRun(rid, "", m.defaultBudget, nil)
+	}
 	m.runs[rid] = r
 	m.mu.Unlock()
-	m.persistRun(r)
+	if restored == nil {
+		m.persistRun(r) // only a genuinely new run needs its initial row written
+	}
 	return r
+}
+
+// restoreFromStore reconstructs a run that already exists in the store (any
+// status), or returns nil if the id is unknown or there is no store. Does its I/O
+// without holding the manager lock.
+func (m *Manager) restoreFromStore(rid string) *Run {
+	if m.store == nil {
+		return nil
+	}
+	rec, err := m.store.GetRun(context.Background(), rid)
+	if err != nil {
+		if !errors.Is(err, storage.ErrNotFound) {
+			m.log.Error("GetOrCreate store lookup failed", "run", rid, "err", err)
+		}
+		return nil
+	}
+	return m.reloadRun(context.Background(), rec)
 }
 
 // List returns snapshots of all runs.
@@ -350,15 +384,29 @@ func (m *Manager) reloadRun(ctx context.Context, rec storage.RunRecord) *Run {
 		Dollars:          rec.UsageDollars,
 		Loops:            rec.UsageLoops,
 	}
+	// A run that had already halted before the restart stays terminal: restore its
+	// exact halt reason so a reused id keeps refusing work (it can't be handed a
+	// fresh budget), rather than re-deriving the halt from usage — which would miss
+	// a kill-switch cancel or a time-budget halt. The partial-step rollback below is
+	// a resume concern (live runs only) and doesn't apply to a terminal run. (#29)
+	terminal := rec.Status == "halted" || rec.Status == "cancelled"
+
 	rolledBack := false
-	if cp, err := m.store.LatestCheckpoint(ctx, rec.ID); err == nil && cp.UsageLoops < rec.UsageLoops {
-		usage = governor.Usage{
-			PromptTokens:     cp.UsagePromptTokens,
-			CompletionTokens: cp.UsageCompletionTokens,
-			Dollars:          cp.UsageDollars,
-			Loops:            cp.UsageLoops,
+	if !terminal {
+		if cp, err := m.store.LatestCheckpoint(ctx, rec.ID); err == nil && cp.UsageLoops < rec.UsageLoops {
+			usage = governor.Usage{
+				PromptTokens:     cp.UsagePromptTokens,
+				CompletionTokens: cp.UsageCompletionTokens,
+				Dollars:          cp.UsageDollars,
+				Loops:            cp.UsageLoops,
+			}
+			rolledBack = true
 		}
-		rolledBack = true
+	}
+
+	opts := []governor.Option{governor.WithRestoredUsage(usage)}
+	if terminal {
+		opts = append(opts, governor.WithRestoredHalt(governor.HaltReason(rec.HaltReason)))
 	}
 	r := &Run{
 		ID:        rec.ID,
@@ -366,7 +414,7 @@ func (m *Manager) reloadRun(ctx context.Context, rec storage.RunRecord) *Run {
 		Budget:    budget,
 		Metadata:  rec.Metadata,
 		mgr:       m,
-		gov:       governor.New(context.Background(), budget, governor.WithRestoredUsage(usage)),
+		gov:       governor.New(context.Background(), budget, opts...),
 		createdAt: rec.CreatedAt,
 		updatedAt: rec.UpdatedAt,
 	}

--- a/internal/runs/manager_test.go
+++ b/internal/runs/manager_test.go
@@ -285,3 +285,81 @@ func TestManager_LoopHaltPersistsStatus(t *testing.T) {
 		t.Fatalf("loop halt not persisted: status=%q reason=%q", got.Status, got.HaltReason)
 	}
 }
+
+// A run that halted before a restart must stay halted when its id is reused via
+// the proxy path (GetOrCreate) — not get handed a fresh, default-budget run that
+// returns 200 instead of 402. (#29)
+func TestManager_GetOrCreateRestoresHaltedRun(t *testing.T) {
+	store, err := storage.OpenSQLite(filepath.Join(t.TempDir(), "reuse-halted.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	noop := slog.New(slog.NewTextHandler(noopWriter{}, nil))
+
+	// Process A: a run with a tiny $0.01 budget trips it and halts.
+	mA := NewManager(governor.Budget{}).WithStore(store, noop)
+	budget := governor.Budget{Dollars: 0.01}
+	rA := mA.Create(CreateOptions{ID: "halted-id", Budget: &budget})
+	step, _ := rA.BeginStep()
+	if err := rA.RecordCall(Call{StepIndex: step, Provider: "p", Model: "m",
+		Dollars: 0.02, Priced: true}); err == nil {
+		t.Fatal("the $0.02 call should have tripped the $0.01 budget")
+	}
+	if !rA.Halted() {
+		t.Fatal("run A should be halted")
+	}
+
+	// --- simulate restart: drop manager A, keep the store. Process B has an
+	// unlimited default budget, so a fresh run for the reused id would NOT halt. ---
+	mB := NewManager(governor.Budget{}).WithStore(store, noop)
+	if _, err := mB.Reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := mB.Get("halted-id"); ok {
+		t.Fatal("a halted run is not reloaded as live (Reload is running-only)")
+	}
+
+	// The proxy reuses the id via GetOrCreate. It must restore the HALTED run and
+	// keep refusing work, not mint a fresh unlimited-budget one.
+	rB := mB.GetOrCreate("halted-id")
+	if !rB.Halted() {
+		t.Fatal("reused halted id came back fresh — the halt did not survive the restart (#29)")
+	}
+	if err := rB.CanProceed(); err == nil {
+		t.Fatal("a restored halted run must refuse further work")
+	}
+	if v := rB.View(); v.Status != "halted" || v.HaltReason != governor.HaltDollarBudget {
+		t.Fatalf("restored run = status %q reason %q; want halted/dollar_budget_exceeded",
+			v.Status, v.HaltReason)
+	}
+
+	// A genuinely new id still materializes a fresh, running run.
+	if fresh := mB.GetOrCreate("brand-new-id"); fresh.Halted() {
+		t.Fatal("a brand-new id should be a fresh running run")
+	}
+}
+
+// A cancelled run (kill switch) must also stay terminal when its id is reused —
+// its usage may be under budget, so only restoring the halt reason recovers it.
+func TestManager_GetOrCreateRestoresCancelledRun(t *testing.T) {
+	store, err := storage.OpenSQLite(filepath.Join(t.TempDir(), "reuse-cancelled.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	noop := slog.New(slog.NewTextHandler(noopWriter{}, nil))
+
+	mA := NewManager(governor.Budget{Dollars: 100}).WithStore(store, noop)
+	rA := mA.Create(CreateOptions{ID: "cancel-id"})
+	rA.Cancel()
+
+	mB := NewManager(governor.Budget{Dollars: 100}).WithStore(store, noop)
+	rB := mB.GetOrCreate("cancel-id")
+	if err := rB.CanProceed(); err == nil {
+		t.Fatal("a restored cancelled run must refuse further work")
+	}
+	if v := rB.View(); v.Status != "cancelled" || v.HaltReason != governor.HaltCancelled {
+		t.Fatalf("restored run = status %q reason %q; want cancelled", v.Status, v.HaltReason)
+	}
+}


### PR DESCRIPTION
**Found via real end-to-end testing of the published image.** Closes #29.

### The bug
`Manager.Reload` restores only `status="running"` runs on startup. A run that had already **halted** (e.g. hit its dollar budget) isn't reloaded, so a proxy call that reused that run-id after a restart fell through to `GetOrCreate`'s cache miss — which **minted a fresh, default-budget run** for the id and returned `200` instead of `402`. The halt didn't survive the restart for already-terminal runs.

Repro: tiny per-run dollar budget → call trips it (halts) → restart daemon (same data volume) → call again with the same `X-RiskKernel-Run-Id` → got `200` (fresh budget) instead of `402`.

### The fix
`GetOrCreate` now **consults the store on a cache miss** and restores an existing run as-is before falling back to a new one:
- a terminal run (budget halt **or** kill-switch cancel) comes back terminal and keeps refusing work;
- only a genuinely unknown id mints a fresh run.

The store lookup runs **without the manager lock** (it's the rare path); a lost create-race closes the discarded governor.

Restoring the *exact* terminal state — not just usage — needs the governor reconstructable as already-halted, so this adds **`governor.WithRestoredHalt(reason)`**. A dollar/token/loop halt would re-trip from restored usage alone, but a **cancel** or a **time-budget** halt would not (usage may be under budget / the clock restarts on resume), and those must stay terminal too. `reloadRun` applies it for terminal records and skips the partial-step rollback (a resume concern for live runs only); `Reload`'s running-only behavior is unchanged.

### Tests
- `TestManager_GetOrCreateRestoresHaltedRun` — the exact repro: Process A halts on a \$0.01 budget; Process B (restart, **unlimited** default budget so a fresh run wouldn't halt) reuses the id via `GetOrCreate` → comes back halted, `CanProceed` refuses, view is `halted/dollar_budget_exceeded`; a brand-new id still gets a fresh running run.
- `TestManager_GetOrCreateRestoresCancelledRun` — a cancelled run (usage under budget) stays terminal, which usage-only restore could not recover.
- `TestWithRestoredHalt` — governor-level coverage across budget halt (context cancelled, all guards refuse), cancel, and the `HaltNone` no-op.

`go vet` clean; full suite green.