### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-13
+
+Governance and compliance. Approvals can route to **Slack**, policy is now
+**code** — reusable bundles via `POST /v1/policies` or a reviewed `riskkernel.yaml`,
+with a dry-run against recorded runs — and a new **compliance evidence export** maps
+RiskKernel's recorded controls to OWASP / EU AI Act references with a tamper-evident
+event log. Plus the published enforcement-overhead number (~150 ns, zero allocations)
+and a public roadmap. No breaking API changes; forward-compatible with v0.5.x state.
+
 ### Added
 - **Published enforcement overhead + a public roadmap.** The deterministic
   enforcement decision is measured at ~150 ns and **zero heap allocations** per
@@ -332,7 +341,8 @@ and a memory you own, in one self-hosted binary. Three integration surfaces
   (keyless) on each `v*` tag; GoReleaser binaries + checksums + GitHub release;
   `govulncheck` + CodeQL in CI. One-line `docker run` quickstart.
 
-[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/prashar32/riskkernel/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/prashar32/riskkernel/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/prashar32/riskkernel/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/prashar32/riskkernel/compare/v0.2.0...v0.3.0

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -71,7 +71,7 @@ orchestration inside the runtime, and a required heavyweight datastore.
 
 ## Status & roadmap
 
-v0.5.0 (released). The runtime is the entire current focus. See
+v0.6.0 (released). The runtime is the entire current focus. See
 [`CHANGELOG.md`](../CHANGELOG.md) for what has landed and the public contract in
 [`api/v1/`](../api/v1) for the stable surface SDKs build on.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ package version
 // These are set via -ldflags "-X github.com/prashar32/riskkernel/internal/version.Version=..."
 var (
 	// Version is the semantic version of this build.
-	Version = "0.5.1-dev"
+	Version = "0.6.1-dev"
 	// Commit is the git commit this binary was built from.
 	Commit = "unknown"
 	// Date is the build date (RFC3339), stamped at release.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "riskkernel"
-version = "0.5.0"
+version = "0.6.0"
 description = "Thin Python client for the RiskKernel reliability runtime (Surface 2)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdks/python/riskkernel/__init__.py
+++ b/sdks/python/riskkernel/__init__.py
@@ -37,7 +37,7 @@ from .runtime import (
     governed_run,
 )
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 __all__ = [
     "RiskKernel",

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@riskkernel/sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@riskkernel/sdk",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@ai-sdk/provider": "^2.0.3",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riskkernel/sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Thin TypeScript client for the RiskKernel reliability runtime (Surface 2).",
   "license": "Apache-2.0",
   "author": "Adarsh Prashar",


### PR DESCRIPTION
Cuts **v0.6.0** — the governance & compliance release.

Headline: approvals route to **Slack**, policy is **code** (reusable bundles via `POST /v1/policies` or a reviewed `riskkernel.yaml`, with a dry-run against recorded runs), a new **compliance evidence export** maps recorded controls to OWASP / EU AI Act references with a tamper-evident event log, plus the published enforcement-overhead number (~150 ns, zero allocations) and a public roadmap.

### Version markers (release checklist)
| File | From → To |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[0.6.0] - 2026-06-13` + fresh `[Unreleased]` + compare links |
| `internal/version/version.go` | `0.5.1-dev` → `0.6.1-dev` |
| `sdks/python` (`pyproject.toml` + `__init__.py`) | `0.5.0` → `0.6.0` |
| `sdks/typescript` (`package.json` + lockfile) | `0.5.0` → `0.6.0` (version-only; `npm ci` clean, `npm audit` 0) |
| `docs/VISION.md` | status line → `v0.6.0` |

The TS bump publishes `@riskkernel/sdk@0.6.0` tokenlessly via the npm workflow on the tag. Lockfile edited surgically (version field only) to avoid dependency drift; `npm ci` consistent and `npm audit` reports 0.

After merge: sync main, then tag `v0.6.0` → binaries + signed image + PyPI + npm.