### PR TITLE
docs(changelog): remove duplicate streaming-proxy entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,14 +50,6 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
   `gate_tools=True` to route `CBEventType.FUNCTION_CALL` through the approval gate.
   `llama-index-core` is lazily imported, so the SDK stays dependency-free; pinned to
   the `llama-index-core` >= 0.10 callback protocol.
-- **Streaming proxy.** `POST /v1/chat/completions` now supports `stream:true`: the
-  budget is enforced before the stream opens, the OpenAI provider's SSE is forwarded
-  to the client verbatim (authentic chunks, no translation) while token usage is
-  metered from the final usage chunk, and the run's context — time budget, kill
-  switch, or client disconnect — cuts a live stream. Dollar/token budgets are
-  checked pre-stream and recorded after (so the next call is refused if it went
-  over). A provider without streaming, and the Anthropic `/v1/messages` endpoint,
-  return a clear 501 rather than silently buffering.
 - **Prometheus `/metrics` endpoint.** Scrape the daemon's own state: governed runs
   by status, halted runs by halt reason, total spend in dollars and tokens, priced
   model calls, and the pending-approval queue depth. Plain Prometheus text


### PR DESCRIPTION
The `[Unreleased]` section listed the streaming proxy twice — the original OpenAI-only entry (from the first streaming PR) and the later one covering both `/v1/chat/completions` and `/v1/messages`. Both survived the merges. This keeps the both-endpoints entry and drops the superseded duplicate. Docs-only; no code change.