### PR TITLE
feat(storage): opt-in Postgres backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 ## [Unreleased]
 
 ### Added
+- **Postgres storage backend (opt-in).** For multi-instance / HA deployments,
+  RiskKernel can run its state on Postgres instead of the default SQLite file — set
+  `RISKKERNEL_DATABASE_URL` to a connection string and the daemon uses Postgres for
+  runs, steps, the cost ledger, tool-call audit trail, approvals, policy bundles,
+  memory facts, and crash-resumable checkpoints. It sits behind the same `Store`
+  interface and the same schema as SQLite (forward-only migrations, downgrade
+  protection), and a shared conformance suite holds the two backends at behavioral
+  parity. SQLite stays the zero-config default; nothing changes unless you set the
+  URL. See [`docs/POSTGRES.md`](docs/POSTGRES.md).
 - **AutoGen adapter (Python SDK).** `from riskkernel.adapters.autogen import
   GovernedChatCompletionClient` — wrap your AutoGen model client once and hand it to
   your existing `AssistantAgent` (or team) to bind it to a governed run with no other

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -20,7 +20,7 @@ every exception here):
 |---|---|
 | **`/v1` REST/gRPC API** | Request/response shapes in `api/v1/`. New optional fields may be added; existing fields keep their meaning. |
 | **Config schema** | Fields explicitly marked `stable` in the schema. Governed by top-level `schemaVersion`. |
-| **SQLite schema** | Forward-migratable only. We never silently change a user's layout. |
+| **Storage schema** | The SQLite and Postgres schemas, forward-migratable only. We never silently change a user's layout. |
 | **CLI flags** | Flags marked stable in `riskkernel --help`. |
 | **Python SDK public methods** | Documented `@governed_run`, `@governed_tool`, `runtime.budget`, `runtime.checkpoint`, `ApprovalGate`. |
 | **OTel attribute names** | The `gen_ai.*` and `riskkernel.*` attribute set pinned in `api/v1/otel-genai.md`. |
@@ -55,7 +55,12 @@ every exception here):
 ## Storage backend
 
 - SQLite (WAL) is the default; Postgres is opt-in behind the same `Store`
-  interface. We never silently change a user's storage layout.
+  interface, selected by setting `RISKKERNEL_DATABASE_URL`. We never silently
+  change a user's storage layout, and never silently switch backends.
+- Both schemas are forward-migratable only (the same downgrade protection applies:
+  the binary refuses to start if the on-disk schema is newer than it understands).
+  The two backends are held at behavioral parity by a shared `Store` conformance
+  test suite.
 
 ## Deprecation policy
 

--- a/docs/POSTGRES.md
+++ b/docs/POSTGRES.md
@@ -1,0 +1,64 @@
+# Postgres backend
+
+SQLite is RiskKernel's default state store — zero-config, a single file you own,
+right for one daemon on one host. For a **multi-instance / HA deployment** (several
+daemons sharing one durable state, rolling restarts, a managed database), RiskKernel
+has an opt-in **Postgres** backend behind the same `Store` interface.
+
+It's opt-in and off by default: nothing changes unless you point RiskKernel at a
+database.
+
+## Enabling it
+
+Set one env var to a standard libpq/pgx connection string:
+
+```bash
+export RISKKERNEL_DATABASE_URL="postgres://user:pass@host:5432/riskkernel?sslmode=require"
+riskkernel serve
+```
+
+When `RISKKERNEL_DATABASE_URL` is set, RiskKernel uses Postgres and ignores the
+SQLite data dir; unset, it falls back to the SQLite file in `RISKKERNEL_DATA_DIR`.
+On startup the daemon logs which backend is active:
+
+```
+state store ready  backend=postgres
+```
+
+The connection string carries credentials, so it follows the same rule as every
+other secret: read from the environment (or `.env`), never logged, never stored in
+state.
+
+## What you get
+
+Everything the SQLite backend does, against shared Postgres state:
+
+- Governed runs, steps, the cost ledger, tool-call audit trail, approvals, policy
+  bundles, episodic memory facts, and crash-resumable checkpoints.
+- **Crash-resume across instances:** a run persisted by one daemon is reloaded and
+  keeps enforcing its already-spent budget after a restart — or on another instance
+  pointed at the same database.
+- The same spend summaries (`riskkernel audit`, the usage rollups), including
+  grouping by run metadata.
+
+The schema mirrors SQLite's exactly (timestamps stored as RFC3339 text, JSON
+marshaled in the application), so behavior is identical. A shared conformance test
+suite runs against both backends to keep them at parity.
+
+## Migrations & safety
+
+- Forward-only migrations run in a transaction on startup (embedded Goose), the
+  same model as SQLite.
+- **Downgrade protection:** the daemon refuses to start if the database schema is
+  newer than the binary understands, so a rolled-back deploy can't corrupt state.
+- No down migrations — roll forward, never back ([`COMPATIBILITY.md`](../COMPATIBILITY.md)).
+
+## Operational notes
+
+- Point every daemon instance at the same database; they coordinate through it.
+- Use a connection pooler (PgBouncer) or a managed Postgres if you run many
+  instances; RiskKernel keeps a small bounded pool per instance.
+- Back up the database as you would any system of record — it holds the auditable
+  cost ledger and the resumable run state.
+- Migrating existing SQLite state into Postgres is not automated; a fresh Postgres
+  database starts empty. Treat the backend choice as a deployment-time decision.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/prashar32/riskkernel
 go 1.25.7
 
 require (
+	github.com/jackc/pgx/v5 v5.10.0
 	github.com/pressly/goose/v3 v3.27.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0
@@ -24,6 +25,9 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -23,6 +24,14 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.10.0 h1:VhSvgU2jSli8o3AqIEOTJr7rZwAEUVo4E4XhR94Zfr0=
+github.com/jackc/pgx/v5 v5.10.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -43,6 +52,9 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
@@ -94,6 +106,7 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 modernc.org/cc/v4 v4.28.2 h1:3tQ0lf2ADtoby2EtSP+J7IE2SHwEJdP8ioR59wx7XpY=

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -172,9 +172,19 @@ func Build(cfg *config.Config) (*Deps, error) {
 	}, nil
 }
 
-// OpenStore creates the data directory and opens the SQLite store (the file the
-// user owns), running forward migrations on the way up.
+// OpenStore opens the durable state backend, running forward migrations on the way
+// up. SQLite (the zero-config file the user owns) is the default; setting
+// RISKKERNEL_DATABASE_URL selects the opt-in Postgres backend instead, for
+// multi-instance / HA deployments.
 func OpenStore(cfg *config.Config, log *slog.Logger) (storage.Store, error) {
+	if cfg.DatabaseURL != "" {
+		store, err := storage.OpenPostgres(cfg.DatabaseURL)
+		if err != nil {
+			return nil, err
+		}
+		log.Info("state store ready", "backend", "postgres")
+		return store, nil
+	}
 	if err := os.MkdirAll(cfg.DataDir, 0o750); err != nil {
 		return nil, fmt.Errorf("creating data dir %q: %w", cfg.DataDir, err)
 	}
@@ -183,7 +193,7 @@ func OpenStore(cfg *config.Config, log *slog.Logger) (storage.Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Info("state store ready", "path", dbPath)
+	log.Info("state store ready", "backend", "sqlite", "path", dbPath)
 	return store, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,12 @@ type Config struct {
 	// DataDir is where the SQLite state file lives. Env: RISKKERNEL_DATA_DIR
 	// (default "./data"). The file in here is the one the user owns.
 	DataDir string
+	// DatabaseURL, when set, selects the opt-in Postgres state backend instead of
+	// the default SQLite file — for multi-instance / HA deployments. A standard
+	// libpq/pgx connection string (postgres://user:pass@host:5432/db?sslmode=...).
+	// Env: RISKKERNEL_DATABASE_URL. Empty keeps the zero-config SQLite default.
+	// Carries credentials — never logged.
+	DatabaseURL string
 	// APIToken is the single-tenant bearer token guarding the API. Env:
 	// RISKKERNEL_API_TOKEN. Empty means auth is disabled (local-only use).
 	APIToken string
@@ -212,6 +218,7 @@ func Load() (*Config, error) {
 	cfg := &Config{
 		Port:             port,
 		DataDir:          getenvDefault("RISKKERNEL_DATA_DIR", "./data"),
+		DatabaseURL:      os.Getenv("RISKKERNEL_DATABASE_URL"),
 		APIToken:         os.Getenv("RISKKERNEL_API_TOKEN"),
 		DefaultProvider:  getenvDefault("RISKKERNEL_DEFAULT_PROVIDER", "anthropic"),
 		AnthropicAPIKey:  os.Getenv("ANTHROPIC_API_KEY"),

--- a/internal/storage/conformance_test.go
+++ b/internal/storage/conformance_test.go
@@ -1,0 +1,277 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// storeConformance exercises the full Store contract against a freshly-migrated,
+// empty backend. Both the SQLite and Postgres backends run it, so the two stay at
+// behavioral parity — a query that works on SQLite but not Postgres (or vice
+// versa) fails here.
+func storeConformance(t *testing.T, s Store) {
+	t.Helper()
+	ctx := context.Background()
+	day1 := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	day2 := time.Date(2026, 6, 2, 10, 0, 0, 0, time.UTC)
+
+	// --- runs: insert, get, update (upsert), list, list-by-status ---
+	r := RunRecord{
+		ID: "run-alpha", Name: "alpha", Status: "running",
+		BudgetTokens: 1000, BudgetDollars: 5, BudgetLoops: 10, BudgetSeconds: 60,
+		UsagePromptTokens: 100, UsageCompletionTokens: 50, UsageDollars: 0.01, UsageLoops: 1,
+		PolicyRef: "bundle-x", Metadata: map[string]string{"team": "alpha"},
+		CreatedAt: day1, UpdatedAt: day1,
+	}
+	if err := s.UpsertRun(ctx, r); err != nil {
+		t.Fatalf("UpsertRun: %v", err)
+	}
+	got, err := s.GetRun(ctx, "run-alpha")
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if got.Name != "alpha" || got.Status != "running" || got.BudgetTokens != 1000 ||
+		got.BudgetDollars != 5 || got.UsageCompletionTokens != 50 || got.PolicyRef != "bundle-x" ||
+		got.Metadata["team"] != "alpha" {
+		t.Fatalf("GetRun roundtrip mismatch: %+v", got)
+	}
+	if !got.CreatedAt.Equal(day1) {
+		t.Errorf("created_at = %v, want %v", got.CreatedAt, day1)
+	}
+
+	// Upsert again (same id) → update status + usage; created_at preserved by caller.
+	r.Status = "halted"
+	r.HaltReason = "token_budget_exceeded"
+	r.UsageDollars = 0.02
+	r.UpdatedAt = day2
+	if err := s.UpsertRun(ctx, r); err != nil {
+		t.Fatalf("UpsertRun update: %v", err)
+	}
+	got, _ = s.GetRun(ctx, "run-alpha")
+	if got.Status != "halted" || got.HaltReason != "token_budget_exceeded" || got.UsageDollars != 0.02 {
+		t.Fatalf("update not applied: %+v", got)
+	}
+
+	// A second run, different metadata, for grouping/list assertions.
+	r2 := RunRecord{ID: "run-beta", Name: "beta", Status: "running",
+		Metadata: map[string]string{"team": "beta"}, CreatedAt: day2, UpdatedAt: day2}
+	if err := s.UpsertRun(ctx, r2); err != nil {
+		t.Fatalf("UpsertRun beta: %v", err)
+	}
+
+	all, err := s.ListRuns(ctx)
+	if err != nil || len(all) != 2 {
+		t.Fatalf("ListRuns = %d (%v), want 2", len(all), err)
+	}
+	if all[0].ID != "run-beta" { // newest (created_at desc) first
+		t.Errorf("ListRuns order: first = %q, want run-beta", all[0].ID)
+	}
+	running, err := s.ListRunsByStatus(ctx, "running")
+	if err != nil || len(running) != 1 || running[0].ID != "run-beta" {
+		t.Fatalf("ListRunsByStatus(running) = %+v (%v)", running, err)
+	}
+
+	// --- steps: upsert, update (close), list ---
+	st := StepRecord{RunID: "run-alpha", Index: 1, Status: "running",
+		PromptTokens: 100, CompletionTokens: 50, Dollars: 0.01, StartedAt: day1}
+	if err := s.UpsertStep(ctx, st); err != nil {
+		t.Fatalf("UpsertStep: %v", err)
+	}
+	ended := day1.Add(time.Second)
+	st.Status, st.EndedAt = "done", &ended
+	if err := s.UpsertStep(ctx, st); err != nil {
+		t.Fatalf("UpsertStep close: %v", err)
+	}
+	steps, err := s.ListSteps(ctx, "run-alpha")
+	if err != nil || len(steps) != 1 || steps[0].Status != "done" || steps[0].EndedAt == nil {
+		t.Fatalf("ListSteps = %+v (%v)", steps, err)
+	}
+
+	// --- ledger: append, list, totals, summarize ---
+	mustLedger(t, s, LedgerEntry{RunID: "run-alpha", StepIndex: 1, Provider: "anthropic",
+		Model: "claude", PromptTokens: 100, CompletionTokens: 50, Dollars: 0.01, Priced: true,
+		ResponseID: "resp-1", CreatedAt: day1})
+	mustLedger(t, s, LedgerEntry{RunID: "run-beta", StepIndex: 1, Provider: "openai",
+		Model: "gpt-4o", PromptTokens: 200, CompletionTokens: 20, Dollars: 0.03, Priced: true,
+		ResponseID: "resp-2", CreatedAt: day2})
+
+	led, err := s.LedgerForRun(ctx, "run-alpha")
+	if err != nil || len(led) != 1 || led[0].Provider != "anthropic" || !led[0].Priced || led[0].ResponseID != "resp-1" {
+		t.Fatalf("LedgerForRun = %+v (%v)", led, err)
+	}
+	tot, err := s.Totals(ctx, "run-alpha")
+	if err != nil || tot.Calls != 1 || tot.PromptTokens != 100 || tot.CompletionTokens != 50 || tot.Dollars != 0.01 {
+		t.Fatalf("Totals = %+v (%v)", tot, err)
+	}
+
+	// Summaries across both runs/ledger rows.
+	byProvider, err := s.SummarizeLedger(ctx, SummarizeOptions{By: "provider"})
+	if err != nil || len(byProvider.Groups) != 2 || byProvider.Total.Calls != 2 || byProvider.Total.Dollars != 0.04 {
+		t.Fatalf("SummarizeLedger provider = %+v (%v)", byProvider, err)
+	}
+	// Highest spend first: openai (0.03) before anthropic (0.01).
+	if byProvider.Groups[0].Key != "openai" {
+		t.Errorf("provider order: first = %q, want openai", byProvider.Groups[0].Key)
+	}
+	byDay, err := s.SummarizeLedger(ctx, SummarizeOptions{By: "day"})
+	if err != nil || len(byDay.Groups) != 2 {
+		t.Fatalf("SummarizeLedger day = %+v (%v)", byDay, err)
+	}
+	byName, err := s.SummarizeLedger(ctx, SummarizeOptions{By: "name"})
+	if err != nil || len(byName.Groups) != 2 {
+		t.Fatalf("SummarizeLedger name = %+v (%v)", byName, err)
+	}
+	byTeam, err := s.SummarizeLedger(ctx, SummarizeOptions{By: "metadata.team"})
+	if err != nil || len(byTeam.Groups) != 2 {
+		t.Fatalf("SummarizeLedger metadata.team = %+v (%v)", byTeam, err)
+	}
+	// metadata grouping must actually read the JSON column, not bucket as '(none)'.
+	keys := map[string]bool{byTeam.Groups[0].Key: true, byTeam.Groups[1].Key: true}
+	if !keys["alpha"] || !keys["beta"] {
+		t.Fatalf("metadata.team groups = %v, want alpha+beta", keys)
+	}
+	// A time window excludes day1's row.
+	windowed, err := s.SummarizeLedger(ctx, SummarizeOptions{By: "provider", Since: &day2})
+	if err != nil || windowed.Total.Calls != 1 || windowed.Groups[0].Key != "openai" {
+		t.Fatalf("SummarizeLedger windowed = %+v (%v)", windowed, err)
+	}
+	if _, err := s.SummarizeLedger(ctx, SummarizeOptions{By: "metadata.bad key"}); err == nil {
+		t.Error("SummarizeLedger should reject an invalid metadata key")
+	}
+
+	// --- tool calls ---
+	if err := s.AppendToolCall(ctx, ToolCallRecord{ID: "tc-1", RunID: "run-alpha", StepIndex: 1,
+		Tool: "mcp://shell", SideEffect: "write", Arguments: map[string]any{"cmd": "ls"},
+		Status: "approved", CreatedAt: day1}); err != nil {
+		t.Fatalf("AppendToolCall: %v", err)
+	}
+	tcs, err := s.ListToolCalls(ctx, "run-alpha")
+	if err != nil || len(tcs) != 1 || tcs[0].Tool != "mcp://shell" || tcs[0].Arguments["cmd"] != "ls" {
+		t.Fatalf("ListToolCalls = %+v (%v)", tcs, err)
+	}
+
+	// --- facts: put, get, update, list ---
+	if err := s.PutFact(ctx, Fact{Namespace: "ns", Key: "k", Value: "v1", RunID: "run-alpha", UpdatedAt: day1}); err != nil {
+		t.Fatalf("PutFact: %v", err)
+	}
+	if err := s.PutFact(ctx, Fact{Namespace: "ns", Key: "k", Value: "v2", UpdatedAt: day2}); err != nil {
+		t.Fatalf("PutFact update: %v", err)
+	}
+	f, err := s.GetFact(ctx, "ns", "k")
+	if err != nil || f.Value != "v2" {
+		t.Fatalf("GetFact = %+v (%v), want value v2", f, err)
+	}
+	facts, err := s.ListFacts(ctx, "ns")
+	if err != nil || len(facts) != 1 {
+		t.Fatalf("ListFacts = %d (%v), want 1", len(facts), err)
+	}
+
+	// --- approvals: create (pending), get, resolve, double-resolve, list ---
+	ap := ApprovalRecord{ID: "ap-1", RunID: "run-alpha", StepIndex: 1, Tool: "mcp://shell",
+		SideEffect: "write", Arguments: map[string]any{"cmd": "rm"}, Status: ApprovalPending,
+		CreatedAt: day1}
+	if err := s.CreateApproval(ctx, ap); err != nil {
+		t.Fatalf("CreateApproval: %v", err)
+	}
+	gotAp, err := s.GetApproval(ctx, "ap-1")
+	if err != nil || gotAp.Status != ApprovalPending || gotAp.Arguments["cmd"] != "rm" {
+		t.Fatalf("GetApproval = %+v (%v)", gotAp, err)
+	}
+	if err := s.ResolveApproval(ctx, "ap-1", ApprovalApproved, "ok", "alice", day2); err != nil {
+		t.Fatalf("ResolveApproval: %v", err)
+	}
+	gotAp, _ = s.GetApproval(ctx, "ap-1")
+	if gotAp.Status != ApprovalApproved || gotAp.DecidedBy != "alice" || gotAp.DecidedAt == nil {
+		t.Fatalf("approval not resolved: %+v", gotAp)
+	}
+	if err := s.ResolveApproval(ctx, "ap-1", ApprovalDenied, "", "", day2); !errors.Is(err, ErrNotFound) {
+		t.Errorf("double-resolve = %v, want ErrNotFound", err)
+	}
+	pend, err := s.ListApprovals(ctx, ApprovalPending)
+	if err != nil || len(pend) != 0 {
+		t.Fatalf("ListApprovals(pending) = %d (%v), want 0", len(pend), err)
+	}
+	if alln, _ := s.ListApprovals(ctx, ""); len(alln) != 1 {
+		t.Fatalf("ListApprovals(all) = %d, want 1", len(alln))
+	}
+
+	// --- policies: upsert, get, update preserves created_at, list ---
+	pol := PolicyRecord{Name: "p1", BudgetTokens: 500, BudgetDollars: 2, BudgetLoops: 5, BudgetSeconds: 30,
+		ToolAllowlist: []string{"mcp://github"}, ApprovalRules: []ApprovalRule{{Tool: "mcp://shell"}},
+		CreatedAt: day1, UpdatedAt: day1}
+	if err := s.UpsertPolicy(ctx, pol); err != nil {
+		t.Fatalf("UpsertPolicy: %v", err)
+	}
+	pol.BudgetTokens = 999
+	pol.UpdatedAt = day2
+	pol.CreatedAt = day2 // caller passes a new created_at, but the store must keep the original
+	if err := s.UpsertPolicy(ctx, pol); err != nil {
+		t.Fatalf("UpsertPolicy update: %v", err)
+	}
+	gotPol, err := s.GetPolicy(ctx, "p1")
+	if err != nil || gotPol.BudgetTokens != 999 || len(gotPol.ToolAllowlist) != 1 ||
+		len(gotPol.ApprovalRules) != 1 || gotPol.ApprovalRules[0].Tool != "mcp://shell" {
+		t.Fatalf("GetPolicy = %+v (%v)", gotPol, err)
+	}
+	if !gotPol.CreatedAt.Equal(day1) {
+		t.Errorf("policy created_at = %v, want preserved %v", gotPol.CreatedAt, day1)
+	}
+	if pols, _ := s.ListPolicies(ctx); len(pols) != 1 {
+		t.Fatalf("ListPolicies = %d, want 1", len(pols))
+	}
+
+	// --- checkpoints: save x2, latest, list ---
+	mustCheckpoint(t, s, CheckpointRecord{RunID: "run-alpha", StepIndex: 1, Name: "cp1",
+		UsagePromptTokens: 100, UsageDollars: 0.01, UsageLoops: 1,
+		Payload: map[string]any{"msg": "first"}, CreatedAt: day1})
+	mustCheckpoint(t, s, CheckpointRecord{RunID: "run-alpha", StepIndex: 2, Name: "cp2",
+		UsagePromptTokens: 200, UsageDollars: 0.02, UsageLoops: 2,
+		Payload: map[string]any{"msg": "second"}, CreatedAt: day2})
+	latest, err := s.LatestCheckpoint(ctx, "run-alpha")
+	if err != nil || latest.Name != "cp2" || latest.StepIndex != 2 || latest.Payload["msg"] != "second" {
+		t.Fatalf("LatestCheckpoint = %+v (%v)", latest, err)
+	}
+	cps, err := s.ListCheckpoints(ctx, "run-alpha")
+	if err != nil || len(cps) != 2 || cps[0].Name != "cp1" {
+		t.Fatalf("ListCheckpoints = %+v (%v)", cps, err)
+	}
+
+	// --- ErrNotFound on misses ---
+	if _, err := s.GetRun(ctx, "nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetRun miss = %v, want ErrNotFound", err)
+	}
+	if _, err := s.GetFact(ctx, "ns", "nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetFact miss = %v, want ErrNotFound", err)
+	}
+	if _, err := s.GetApproval(ctx, "nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetApproval miss = %v, want ErrNotFound", err)
+	}
+	if _, err := s.GetPolicy(ctx, "nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetPolicy miss = %v, want ErrNotFound", err)
+	}
+	if _, err := s.LatestCheckpoint(ctx, "nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("LatestCheckpoint miss = %v, want ErrNotFound", err)
+	}
+}
+
+func mustLedger(t *testing.T, s Store, e LedgerEntry) {
+	t.Helper()
+	if err := s.AppendLedger(context.Background(), e); err != nil {
+		t.Fatalf("AppendLedger: %v", err)
+	}
+}
+
+func mustCheckpoint(t *testing.T, s Store, c CheckpointRecord) {
+	t.Helper()
+	if err := s.SaveCheckpoint(context.Background(), c); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+}
+
+// TestSQLiteConformance runs the shared Store conformance suite against SQLite, so
+// the suite itself is exercised in ordinary CI and stays honest about parity.
+func TestSQLiteConformance(t *testing.T) {
+	storeConformance(t, openTemp(t))
+}

--- a/internal/storage/migrations/postgres/00001_init.sql
+++ b/internal/storage/migrations/postgres/00001_init.sql
@@ -1,0 +1,69 @@
+-- +goose Up
+-- Initial schema: governed runs, their steps, tool calls, and the cost ledger.
+-- Postgres mirror of the SQLite schema (same columns, same semantics) so a Store
+-- consumer behaves identically on either backend. Timestamps are RFC3339 text
+-- (UTC), marshaled in Go, so the scan/marshal code is shared across backends.
+-- Money lives in the ledger and must stay auditable (`riskkernel audit export`).
+
+CREATE TABLE runs (
+    id                      TEXT             PRIMARY KEY,
+    name                    TEXT             NOT NULL DEFAULT '',
+    status                  TEXT             NOT NULL,
+    halt_reason             TEXT             NOT NULL DEFAULT '',
+    budget_tokens           BIGINT           NOT NULL DEFAULT 0,
+    budget_dollars          DOUBLE PRECISION NOT NULL DEFAULT 0,
+    budget_loops            BIGINT           NOT NULL DEFAULT 0,
+    budget_seconds          BIGINT           NOT NULL DEFAULT 0,
+    usage_prompt_tokens     BIGINT           NOT NULL DEFAULT 0,
+    usage_completion_tokens BIGINT           NOT NULL DEFAULT 0,
+    usage_dollars           DOUBLE PRECISION NOT NULL DEFAULT 0,
+    usage_loops             BIGINT           NOT NULL DEFAULT 0,
+    metadata                TEXT             NOT NULL DEFAULT '{}',
+    created_at              TEXT             NOT NULL,
+    updated_at              TEXT             NOT NULL
+);
+
+CREATE TABLE steps (
+    run_id            TEXT             NOT NULL REFERENCES runs(id),
+    idx               BIGINT           NOT NULL,
+    status            TEXT             NOT NULL,
+    prompt_tokens     BIGINT           NOT NULL DEFAULT 0,
+    completion_tokens BIGINT           NOT NULL DEFAULT 0,
+    dollars           DOUBLE PRECISION NOT NULL DEFAULT 0,
+    started_at        TEXT             NOT NULL,
+    ended_at          TEXT,
+    PRIMARY KEY (run_id, idx)
+);
+
+CREATE TABLE tool_calls (
+    id          TEXT   PRIMARY KEY,
+    run_id      TEXT   NOT NULL REFERENCES runs(id),
+    step_idx    BIGINT NOT NULL,
+    tool        TEXT   NOT NULL,
+    side_effect TEXT   NOT NULL DEFAULT '',
+    arguments   TEXT   NOT NULL DEFAULT '{}',
+    status      TEXT   NOT NULL,
+    created_at  TEXT   NOT NULL
+);
+
+CREATE TABLE cost_ledger (
+    id                BIGINT           GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    run_id            TEXT             NOT NULL REFERENCES runs(id),
+    step_idx          BIGINT           NOT NULL,
+    provider          TEXT             NOT NULL,
+    model             TEXT             NOT NULL,
+    prompt_tokens     BIGINT           NOT NULL,
+    completion_tokens BIGINT           NOT NULL,
+    dollars           DOUBLE PRECISION NOT NULL,
+    priced            BIGINT           NOT NULL DEFAULT 1,
+    response_id       TEXT             NOT NULL DEFAULT '',
+    created_at        TEXT             NOT NULL
+);
+
+CREATE INDEX idx_steps_run ON steps(run_id);
+CREATE INDEX idx_tool_calls_run ON tool_calls(run_id);
+CREATE INDEX idx_ledger_run ON cost_ledger(run_id);
+
+-- +goose Down
+-- RiskKernel uses forward-only migrations (COMPATIBILITY.md / Temporal policy).
+-- A down migration is intentionally not provided; roll forward, never back.

--- a/internal/storage/migrations/postgres/00002_checkpoints.sql
+++ b/internal/storage/migrations/postgres/00002_checkpoints.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- Crash-resumable checkpoints (Postgres mirror). A checkpoint snapshots a run's
+-- usage at a step plus an opaque user-supplied payload that a resuming agent
+-- restarts from. The run row stays the source of truth for usage/budget on resume;
+-- checkpoints add the resumable payload and a per-step history.
+
+CREATE TABLE checkpoints (
+    id                      BIGINT           GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    run_id                  TEXT             NOT NULL REFERENCES runs(id),
+    step_idx                BIGINT           NOT NULL,
+    name                    TEXT             NOT NULL DEFAULT '',
+    usage_prompt_tokens     BIGINT           NOT NULL DEFAULT 0,
+    usage_completion_tokens BIGINT           NOT NULL DEFAULT 0,
+    usage_dollars           DOUBLE PRECISION NOT NULL DEFAULT 0,
+    usage_loops             BIGINT           NOT NULL DEFAULT 0,
+    payload                 TEXT             NOT NULL DEFAULT '{}',
+    created_at              TEXT             NOT NULL
+);
+
+CREATE INDEX idx_checkpoints_run ON checkpoints(run_id);
+
+-- +goose Down
+-- Forward-only migrations (COMPATIBILITY.md). No down migration is provided.

--- a/internal/storage/migrations/postgres/00003_approvals.sql
+++ b/internal/storage/migrations/postgres/00003_approvals.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- Human-in-the-loop approvals (Postgres mirror). A side-effecting tool call that
+-- policy gates pauses here as a pending row until a human approves or denies it.
+-- Resolved rows are an audit trail of who allowed which side effect, when, and why.
+
+CREATE TABLE approvals (
+    id          TEXT   PRIMARY KEY,
+    run_id      TEXT   NOT NULL REFERENCES runs(id),
+    step_idx    BIGINT NOT NULL,
+    tool        TEXT   NOT NULL,
+    side_effect TEXT   NOT NULL DEFAULT '',
+    arguments   TEXT   NOT NULL DEFAULT '{}',
+    status      TEXT   NOT NULL, -- pending | approved | denied
+    reason      TEXT   NOT NULL DEFAULT '',
+    decided_by  TEXT   NOT NULL DEFAULT '',
+    created_at  TEXT   NOT NULL,
+    decided_at  TEXT
+);
+
+CREATE INDEX idx_approvals_run ON approvals(run_id);
+CREATE INDEX idx_approvals_status ON approvals(status);
+
+-- +goose Down
+-- Forward-only migrations (COMPATIBILITY.md). No down migration is provided.

--- a/internal/storage/migrations/postgres/00004_memory_facts.sql
+++ b/internal/storage/migrations/postgres/00004_memory_facts.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- Episodic memory (Postgres mirror): small, fact-granular key/value state an agent
+-- accumulates across a run (distinct from the git-native markdown/YAML the user
+-- owns on disk). Keyed by namespace + key; run_id is optional attribution (no FK —
+-- facts may be global, and a fact write must not fail on an unknown run).
+
+CREATE TABLE memory_facts (
+    namespace  TEXT NOT NULL,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    run_id     TEXT,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (namespace, key)
+);
+
+CREATE INDEX idx_memory_facts_ns ON memory_facts(namespace);
+
+-- +goose Down
+-- Forward-only migrations (COMPATIBILITY.md). No down migration is provided.

--- a/internal/storage/migrations/postgres/00005_policies.sql
+++ b/internal/storage/migrations/postgres/00005_policies.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- Reusable, named policy bundles (Postgres mirror). A run can reference one by name
+-- (policyRef on POST /v1/runs) instead of inlining its budget — the deterministic
+-- seam the AgentProfile model builds on. Re-registering the same name updates it.
+
+CREATE TABLE policies (
+    name           TEXT             PRIMARY KEY,
+    budget_tokens  BIGINT           NOT NULL DEFAULT 0,
+    budget_dollars DOUBLE PRECISION NOT NULL DEFAULT 0,
+    budget_loops   BIGINT           NOT NULL DEFAULT 0,
+    budget_seconds BIGINT           NOT NULL DEFAULT 0,
+    tool_allowlist TEXT             NOT NULL DEFAULT '[]', -- JSON array of tool names
+    approval_rules TEXT             NOT NULL DEFAULT '[]', -- JSON array of {tool, sideEffect}
+    created_at     TEXT             NOT NULL,
+    updated_at     TEXT             NOT NULL
+);
+
+-- +goose Down
+-- Forward-only migrations (COMPATIBILITY.md). No down migration is provided.

--- a/internal/storage/migrations/postgres/00006_run_policy_ref.sql
+++ b/internal/storage/migrations/postgres/00006_run_policy_ref.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Record which policy bundle a run was created under (POST /v1/runs policyRef), so
+-- the bundle's tool allowlist and approval rules can be enforced per-run — not just
+-- its budget. Empty means no bundle (global config applies). Postgres mirror.
+
+ALTER TABLE runs ADD COLUMN policy_ref TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+-- Forward-only migrations (COMPATIBILITY.md). No down migration is provided.

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -1,0 +1,633 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver "pgx" for Postgres
+	"github.com/pressly/goose/v3"
+)
+
+//go:embed migrations/postgres/*.sql
+var pgMigrationsFS embed.FS
+
+const pgMigrationsDir = "migrations/postgres"
+
+// Postgres is the opt-in Store backend for multi-instance / HA deployments. It
+// implements the same Store interface as the default SQLite backend against the
+// same schema (timestamps as RFC3339 text, JSON marshaled in Go), so every
+// package-level scan/marshal helper is shared — only the SQL dialect (placeholder
+// style, the metadata JSON accessor) and the DDL differ. SQLite stays the default;
+// Postgres is selected only when a connection string is configured.
+type Postgres struct {
+	db *sql.DB
+}
+
+// OpenPostgres connects to Postgres using a standard libpq/pgx connection string
+// (e.g. postgres://user:pass@host:5432/db?sslmode=require), applies pending
+// forward migrations in a transaction, and enforces downgrade protection.
+func OpenPostgres(dsn string) (*Postgres, error) {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("storage: open postgres: %w", err)
+	}
+	// Postgres handles concurrent writers — keep a modest, bounded pool.
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(time.Hour)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("storage: ping postgres: %w", err)
+	}
+
+	p := &Postgres{db: db}
+	if err := p.migrate(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return p, nil
+}
+
+// migrate applies embedded forward migrations after enforcing that the on-disk
+// schema is not newer than this binary understands (downgrade protection).
+func (p *Postgres) migrate() error {
+	goose.SetBaseFS(pgMigrationsFS)
+	goose.SetLogger(quietGooseLogger{})
+	if err := goose.SetDialect("postgres"); err != nil {
+		return fmt.Errorf("storage: set goose dialect: %w", err)
+	}
+
+	maxKnown, err := maxMigrationVersionFS(pgMigrationsFS, pgMigrationsDir)
+	if err != nil {
+		return err
+	}
+	current, err := goose.GetDBVersion(p.db)
+	if err != nil {
+		return fmt.Errorf("storage: read schema version: %w", err)
+	}
+	if current > maxKnown {
+		return fmt.Errorf("%w (on-disk v%d > binary v%d)", ErrSchemaTooNew, current, maxKnown)
+	}
+	if err := goose.Up(p.db, pgMigrationsDir); err != nil {
+		return fmt.Errorf("storage: apply migrations: %w", err)
+	}
+	return nil
+}
+
+// maxMigrationVersionFS returns the highest migration version in the given
+// embedded directory (the numeric prefix of each filename).
+func maxMigrationVersionFS(fsys fs.FS, dir string) (int64, error) {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return 0, fmt.Errorf("storage: read embedded migrations: %w", err)
+	}
+	var max int64
+	for _, e := range entries {
+		name := path.Base(e.Name())
+		if !strings.HasSuffix(name, ".sql") {
+			continue
+		}
+		prefix, _, _ := strings.Cut(name, "_")
+		v, err := strconv.ParseInt(prefix, 10, 64)
+		if err != nil {
+			continue
+		}
+		if v > max {
+			max = v
+		}
+	}
+	return max, nil
+}
+
+// Close closes the connection pool.
+func (p *Postgres) Close() error { return p.db.Close() }
+
+// --- runs ---
+
+func (p *Postgres) UpsertRun(ctx context.Context, r RunRecord) error {
+	meta, err := marshalMeta(r.Metadata)
+	if err != nil {
+		return err
+	}
+	_, err = p.db.ExecContext(ctx, `
+		INSERT INTO runs (id, name, status, halt_reason,
+			budget_tokens, budget_dollars, budget_loops, budget_seconds,
+			usage_prompt_tokens, usage_completion_tokens, usage_dollars, usage_loops,
+			metadata, created_at, updated_at, policy_ref)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+		ON CONFLICT(id) DO UPDATE SET
+			name=excluded.name, status=excluded.status, halt_reason=excluded.halt_reason,
+			budget_tokens=excluded.budget_tokens, budget_dollars=excluded.budget_dollars,
+			budget_loops=excluded.budget_loops, budget_seconds=excluded.budget_seconds,
+			usage_prompt_tokens=excluded.usage_prompt_tokens,
+			usage_completion_tokens=excluded.usage_completion_tokens,
+			usage_dollars=excluded.usage_dollars, usage_loops=excluded.usage_loops,
+			metadata=excluded.metadata, updated_at=excluded.updated_at`,
+		r.ID, r.Name, r.Status, r.HaltReason,
+		r.BudgetTokens, r.BudgetDollars, r.BudgetLoops, r.BudgetSeconds,
+		r.UsagePromptTokens, r.UsageCompletionTokens, r.UsageDollars, r.UsageLoops,
+		meta, fmtTime(r.CreatedAt), fmtTime(r.UpdatedAt), r.PolicyRef)
+	if err != nil {
+		return fmt.Errorf("storage: upsert run: %w", err)
+	}
+	return nil
+}
+
+func (p *Postgres) GetRun(ctx context.Context, id string) (RunRecord, error) {
+	row := p.db.QueryRowContext(ctx, `SELECT `+runColumns+` FROM runs WHERE id = $1`, id)
+	r, err := scanRun(row)
+	if err == sql.ErrNoRows {
+		return RunRecord{}, ErrNotFound
+	}
+	return r, err
+}
+
+func (p *Postgres) ListRuns(ctx context.Context) ([]RunRecord, error) {
+	rows, err := p.db.QueryContext(ctx, `SELECT `+runColumns+` FROM runs ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list runs: %w", err)
+	}
+	defer rows.Close()
+	var out []RunRecord
+	for rows.Next() {
+		r, err := scanRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (p *Postgres) ListRunsByStatus(ctx context.Context, status string) ([]RunRecord, error) {
+	rows, err := p.db.QueryContext(ctx,
+		`SELECT `+runColumns+` FROM runs WHERE status = $1 ORDER BY created_at DESC`, status)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list runs by status: %w", err)
+	}
+	defer rows.Close()
+	var out []RunRecord
+	for rows.Next() {
+		r, err := scanRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// --- steps ---
+
+func (p *Postgres) UpsertStep(ctx context.Context, st StepRecord) error {
+	_, err := p.db.ExecContext(ctx, `
+		INSERT INTO steps (run_id, idx, status, prompt_tokens, completion_tokens, dollars, started_at, ended_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+		ON CONFLICT(run_id, idx) DO UPDATE SET
+			status=excluded.status, prompt_tokens=excluded.prompt_tokens,
+			completion_tokens=excluded.completion_tokens, dollars=excluded.dollars,
+			ended_at=excluded.ended_at`,
+		st.RunID, st.Index, st.Status, st.PromptTokens, st.CompletionTokens, st.Dollars,
+		fmtTime(st.StartedAt), fmtTimePtr(st.EndedAt))
+	if err != nil {
+		return fmt.Errorf("storage: upsert step: %w", err)
+	}
+	return nil
+}
+
+func (p *Postgres) ListSteps(ctx context.Context, runID string) ([]StepRecord, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT run_id, idx, status, prompt_tokens, completion_tokens, dollars, started_at, ended_at
+		FROM steps WHERE run_id = $1 ORDER BY idx`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list steps: %w", err)
+	}
+	defer rows.Close()
+	var out []StepRecord
+	for rows.Next() {
+		var st StepRecord
+		var started string
+		var ended sql.NullString
+		if err := rows.Scan(&st.RunID, &st.Index, &st.Status, &st.PromptTokens,
+			&st.CompletionTokens, &st.Dollars, &started, &ended); err != nil {
+			return nil, err
+		}
+		st.StartedAt = parseTime(started)
+		if ended.Valid && ended.String != "" {
+			t := parseTime(ended.String)
+			st.EndedAt = &t
+		}
+		out = append(out, st)
+	}
+	return out, rows.Err()
+}
+
+// --- ledger ---
+
+func (p *Postgres) AppendLedger(ctx context.Context, e LedgerEntry) error {
+	_, err := p.db.ExecContext(ctx, `
+		INSERT INTO cost_ledger (run_id, step_idx, provider, model,
+			prompt_tokens, completion_tokens, dollars, priced, response_id, created_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+		e.RunID, e.StepIndex, e.Provider, e.Model,
+		e.PromptTokens, e.CompletionTokens, e.Dollars, boolToInt(e.Priced), e.ResponseID,
+		fmtTime(e.CreatedAt))
+	if err != nil {
+		return fmt.Errorf("storage: append ledger: %w", err)
+	}
+	return nil
+}
+
+func (p *Postgres) LedgerForRun(ctx context.Context, runID string) ([]LedgerEntry, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT run_id, step_idx, provider, model, prompt_tokens, completion_tokens,
+			dollars, priced, response_id, created_at
+		FROM cost_ledger WHERE run_id = $1 ORDER BY id`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: ledger for run: %w", err)
+	}
+	defer rows.Close()
+	var out []LedgerEntry
+	for rows.Next() {
+		var e LedgerEntry
+		var priced int
+		var created string
+		if err := rows.Scan(&e.RunID, &e.StepIndex, &e.Provider, &e.Model,
+			&e.PromptTokens, &e.CompletionTokens, &e.Dollars, &priced, &e.ResponseID, &created); err != nil {
+			return nil, err
+		}
+		e.Priced = priced != 0
+		e.CreatedAt = parseTime(created)
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+func (p *Postgres) Totals(ctx context.Context, runID string) (LedgerTotals, error) {
+	row := p.db.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(completion_tokens),0),
+			COALESCE(SUM(dollars),0)
+		FROM cost_ledger WHERE run_id = $1`, runID)
+	t := LedgerTotals{RunID: runID}
+	if err := row.Scan(&t.Calls, &t.PromptTokens, &t.CompletionTokens, &t.Dollars); err != nil {
+		return LedgerTotals{}, fmt.Errorf("storage: totals: %w", err)
+	}
+	return t, nil
+}
+
+// SummarizeLedger mirrors the SQLite aggregation. The grouping expression is chosen
+// from a fixed whitelist (structural, not a bound parameter); the metadata key is
+// validated and bound as a value, so nothing is built from raw user input unsafely.
+// The only dialect difference from SQLite is the metadata accessor: Postgres reads
+// the JSON-in-text column via `metadata::jsonb ->> key` instead of json_extract.
+func (p *Postgres) SummarizeLedger(ctx context.Context, opts SummarizeOptions) (UsageSummary, error) {
+	var groupExpr, metaArg string
+	needRuns := false
+	n := 0 // next positional placeholder index
+	next := func() string { n++; return "$" + strconv.Itoa(n) }
+
+	switch {
+	case opts.By == "provider":
+		groupExpr = "l.provider"
+	case opts.By == "model":
+		groupExpr = "l.model"
+	case opts.By == "day":
+		groupExpr = "substr(l.created_at, 1, 10)" // RFC3339 date prefix (UTC)
+	case opts.By == "name":
+		groupExpr, needRuns = "r.name", true
+	case strings.HasPrefix(opts.By, "metadata."):
+		key := strings.TrimPrefix(opts.By, "metadata.")
+		if !validMetaKey(key) {
+			return UsageSummary{}, fmt.Errorf("storage: invalid metadata key %q", key)
+		}
+		groupExpr, metaArg, needRuns = "(r.metadata::jsonb ->> "+next()+")", key, true
+	default:
+		return UsageSummary{}, fmt.Errorf("storage: unsupported group dimension %q", opts.By)
+	}
+
+	from := "cost_ledger l"
+	if needRuns {
+		from += " JOIN runs r ON r.id = l.run_id"
+	}
+
+	var args []any
+	if metaArg != "" { // the metadata key is the first placeholder, in SELECT
+		args = append(args, metaArg)
+	}
+	var conds []string
+	if opts.Since != nil {
+		conds = append(conds, "l.created_at >= "+next())
+		args = append(args, fmtTime(*opts.Since))
+	}
+	if opts.Until != nil {
+		conds = append(conds, "l.created_at < "+next())
+		args = append(args, fmtTime(*opts.Until))
+	}
+	where := ""
+	if len(conds) > 0 {
+		where = " WHERE " + strings.Join(conds, " AND ")
+	}
+
+	q := fmt.Sprintf(`
+		SELECT COALESCE(%s, '(none)') AS k,
+			COUNT(*), COALESCE(SUM(l.prompt_tokens), 0), COALESCE(SUM(l.completion_tokens), 0),
+			COALESCE(SUM(l.dollars), 0)
+		FROM %s%s
+		GROUP BY k
+		ORDER BY SUM(l.dollars) DESC, k ASC`, groupExpr, from, where)
+
+	rows, err := p.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return UsageSummary{}, fmt.Errorf("storage: summarize ledger: %w", err)
+	}
+	defer rows.Close()
+
+	out := UsageSummary{By: opts.By, Groups: []UsageGroup{}, Total: UsageGroup{Key: "total"}}
+	for rows.Next() {
+		var g UsageGroup
+		if err := rows.Scan(&g.Key, &g.Calls, &g.PromptTokens, &g.CompletionTokens, &g.Dollars); err != nil {
+			return UsageSummary{}, err
+		}
+		out.Groups = append(out.Groups, g)
+		out.Total.Calls += g.Calls
+		out.Total.PromptTokens += g.PromptTokens
+		out.Total.CompletionTokens += g.CompletionTokens
+		out.Total.Dollars += g.Dollars
+	}
+	return out, rows.Err()
+}
+
+// --- tool calls ---
+
+func (p *Postgres) AppendToolCall(ctx context.Context, t ToolCallRecord) error {
+	args, err := json.Marshal(orEmptyMap(t.Arguments))
+	if err != nil {
+		return fmt.Errorf("storage: marshal tool args: %w", err)
+	}
+	_, err = p.db.ExecContext(ctx, `
+		INSERT INTO tool_calls (id, run_id, step_idx, tool, side_effect, arguments, status, created_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+		t.ID, t.RunID, t.StepIndex, t.Tool, t.SideEffect, string(args), t.Status, fmtTime(t.CreatedAt))
+	if err != nil {
+		return fmt.Errorf("storage: append tool call: %w", err)
+	}
+	return nil
+}
+
+func (p *Postgres) ListToolCalls(ctx context.Context, runID string) ([]ToolCallRecord, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT id, run_id, step_idx, tool, side_effect, arguments, status, created_at
+		FROM tool_calls WHERE run_id = $1 ORDER BY step_idx, created_at, id`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list tool calls: %w", err)
+	}
+	defer rows.Close()
+	var out []ToolCallRecord
+	for rows.Next() {
+		var t ToolCallRecord
+		var args, created string
+		if err := rows.Scan(&t.ID, &t.RunID, &t.StepIndex, &t.Tool,
+			&t.SideEffect, &args, &t.Status, &created); err != nil {
+			return nil, err
+		}
+		t.Arguments = unmarshalArgs(args)
+		t.CreatedAt = parseTime(created)
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// --- memory facts ---
+
+func (p *Postgres) PutFact(ctx context.Context, f Fact) error {
+	_, err := p.db.ExecContext(ctx, `
+		INSERT INTO memory_facts (namespace, key, value, run_id, updated_at)
+		VALUES ($1,$2,$3,$4,$5)
+		ON CONFLICT(namespace, key) DO UPDATE SET
+			value=excluded.value, run_id=excluded.run_id, updated_at=excluded.updated_at`,
+		f.Namespace, f.Key, f.Value, nullStr(f.RunID), fmtTime(f.UpdatedAt))
+	if err != nil {
+		return fmt.Errorf("storage: put fact: %w", err)
+	}
+	return nil
+}
+
+func (p *Postgres) GetFact(ctx context.Context, namespace, key string) (Fact, error) {
+	row := p.db.QueryRowContext(ctx,
+		`SELECT namespace, key, value, run_id, updated_at FROM memory_facts WHERE namespace = $1 AND key = $2`,
+		namespace, key)
+	f, err := scanFact(row)
+	if err == sql.ErrNoRows {
+		return Fact{}, ErrNotFound
+	}
+	return f, err
+}
+
+func (p *Postgres) ListFacts(ctx context.Context, namespace string) ([]Fact, error) {
+	rows, err := p.db.QueryContext(ctx,
+		`SELECT namespace, key, value, run_id, updated_at FROM memory_facts WHERE namespace = $1 ORDER BY key`,
+		namespace)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list facts: %w", err)
+	}
+	defer rows.Close()
+	var out []Fact
+	for rows.Next() {
+		f, err := scanFact(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, rows.Err()
+}
+
+// --- approvals ---
+
+func (p *Postgres) CreateApproval(ctx context.Context, a ApprovalRecord) error {
+	args, err := json.Marshal(orEmptyMapAny(a.Arguments))
+	if err != nil {
+		return fmt.Errorf("storage: marshal approval args: %w", err)
+	}
+	_, err = p.db.ExecContext(ctx, `
+		INSERT INTO approvals (id, run_id, step_idx, tool, side_effect, arguments, status, reason, decided_by, created_at, decided_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+		a.ID, a.RunID, a.StepIndex, a.Tool, a.SideEffect, string(args),
+		a.Status, a.Reason, a.DecidedBy, fmtTime(a.CreatedAt), fmtTimePtr(a.DecidedAt))
+	if err != nil {
+		return fmt.Errorf("storage: create approval: %w", err)
+	}
+	return nil
+}
+
+func (p *Postgres) GetApproval(ctx context.Context, id string) (ApprovalRecord, error) {
+	row := p.db.QueryRowContext(ctx, `
+		SELECT id, run_id, step_idx, tool, side_effect, arguments, status, reason, decided_by, created_at, decided_at
+		FROM approvals WHERE id = $1`, id)
+	a, err := scanApproval(row)
+	if err == sql.ErrNoRows {
+		return ApprovalRecord{}, ErrNotFound
+	}
+	return a, err
+}
+
+func (p *Postgres) ResolveApproval(ctx context.Context, id, status, reason, decidedBy string, decidedAt time.Time) error {
+	res, err := p.db.ExecContext(ctx, `
+		UPDATE approvals SET status = $1, reason = $2, decided_by = $3, decided_at = $4
+		WHERE id = $5 AND status = $6`,
+		status, reason, decidedBy, fmtTime(decidedAt), id, ApprovalPending)
+	if err != nil {
+		return fmt.Errorf("storage: resolve approval: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (p *Postgres) ListApprovals(ctx context.Context, status string) ([]ApprovalRecord, error) {
+	q := `SELECT id, run_id, step_idx, tool, side_effect, arguments, status, reason, decided_by, created_at, decided_at
+		FROM approvals`
+	var rows *sql.Rows
+	var err error
+	if status == "" {
+		rows, err = p.db.QueryContext(ctx, q+` ORDER BY created_at DESC`)
+	} else {
+		rows, err = p.db.QueryContext(ctx, q+` WHERE status = $1 ORDER BY created_at DESC`, status)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("storage: list approvals: %w", err)
+	}
+	defer rows.Close()
+	var out []ApprovalRecord
+	for rows.Next() {
+		a, err := scanApproval(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// --- policies ---
+
+func (p *Postgres) UpsertPolicy(ctx context.Context, pol PolicyRecord) error {
+	allow, err := json.Marshal(orEmptyStrings(pol.ToolAllowlist))
+	if err != nil {
+		return fmt.Errorf("storage: marshal policy allowlist: %w", err)
+	}
+	rules, err := json.Marshal(orEmptyRules(pol.ApprovalRules))
+	if err != nil {
+		return fmt.Errorf("storage: marshal policy rules: %w", err)
+	}
+	_, err = p.db.ExecContext(ctx, `
+		INSERT INTO policies (name, budget_tokens, budget_dollars, budget_loops, budget_seconds, tool_allowlist, approval_rules, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+		ON CONFLICT(name) DO UPDATE SET
+			budget_tokens=excluded.budget_tokens, budget_dollars=excluded.budget_dollars,
+			budget_loops=excluded.budget_loops, budget_seconds=excluded.budget_seconds,
+			tool_allowlist=excluded.tool_allowlist, approval_rules=excluded.approval_rules,
+			updated_at=excluded.updated_at`,
+		pol.Name, pol.BudgetTokens, pol.BudgetDollars, pol.BudgetLoops, pol.BudgetSeconds,
+		string(allow), string(rules), fmtTime(pol.CreatedAt), fmtTime(pol.UpdatedAt))
+	if err != nil {
+		return fmt.Errorf("storage: upsert policy: %w", err)
+	}
+	return nil
+}
+
+func (p *Postgres) GetPolicy(ctx context.Context, name string) (PolicyRecord, error) {
+	row := p.db.QueryRowContext(ctx, `
+		SELECT name, budget_tokens, budget_dollars, budget_loops, budget_seconds, tool_allowlist, approval_rules, created_at, updated_at
+		FROM policies WHERE name = $1`, name)
+	pol, err := scanPolicy(row)
+	if err == sql.ErrNoRows {
+		return PolicyRecord{}, ErrNotFound
+	}
+	return pol, err
+}
+
+func (p *Postgres) ListPolicies(ctx context.Context) ([]PolicyRecord, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT name, budget_tokens, budget_dollars, budget_loops, budget_seconds, tool_allowlist, approval_rules, created_at, updated_at
+		FROM policies ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list policies: %w", err)
+	}
+	defer rows.Close()
+	var out []PolicyRecord
+	for rows.Next() {
+		pol, err := scanPolicy(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, pol)
+	}
+	return out, rows.Err()
+}
+
+// --- checkpoints ---
+
+func (p *Postgres) SaveCheckpoint(ctx context.Context, c CheckpointRecord) error {
+	payload, err := json.Marshal(orEmptyMapAny(c.Payload))
+	if err != nil {
+		return fmt.Errorf("storage: marshal checkpoint payload: %w", err)
+	}
+	_, err = p.db.ExecContext(ctx, `
+		INSERT INTO checkpoints (run_id, step_idx, name,
+			usage_prompt_tokens, usage_completion_tokens, usage_dollars, usage_loops,
+			payload, created_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+		c.RunID, c.StepIndex, c.Name,
+		c.UsagePromptTokens, c.UsageCompletionTokens, c.UsageDollars, c.UsageLoops,
+		string(payload), fmtTime(c.CreatedAt))
+	if err != nil {
+		return fmt.Errorf("storage: save checkpoint: %w", err)
+	}
+	return nil
+}
+
+func (p *Postgres) LatestCheckpoint(ctx context.Context, runID string) (CheckpointRecord, error) {
+	row := p.db.QueryRowContext(ctx, `
+		SELECT run_id, step_idx, name, usage_prompt_tokens, usage_completion_tokens,
+			usage_dollars, usage_loops, payload, created_at
+		FROM checkpoints WHERE run_id = $1 ORDER BY id DESC LIMIT 1`, runID)
+	c, err := scanCheckpoint(row)
+	if err == sql.ErrNoRows {
+		return CheckpointRecord{}, ErrNotFound
+	}
+	return c, err
+}
+
+func (p *Postgres) ListCheckpoints(ctx context.Context, runID string) ([]CheckpointRecord, error) {
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT run_id, step_idx, name, usage_prompt_tokens, usage_completion_tokens,
+			usage_dollars, usage_loops, payload, created_at
+		FROM checkpoints WHERE run_id = $1 ORDER BY id`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list checkpoints: %w", err)
+	}
+	defer rows.Close()
+	var out []CheckpointRecord
+	for rows.Next() {
+		c, err := scanCheckpoint(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}

--- a/internal/storage/postgres_test.go
+++ b/internal/storage/postgres_test.go
@@ -1,0 +1,79 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// TestPostgresConformance runs the shared Store conformance suite against a real
+// Postgres, proving the Postgres backend is at parity with SQLite. It is skipped
+// unless RISKKERNEL_TEST_DATABASE_URL points at a disposable Postgres database —
+// CI provides one as a service; locally, point it at a scratch instance. The test
+// resets the target's public schema first, so it must be a throwaway database.
+func TestPostgresConformance(t *testing.T) {
+	dsn := os.Getenv("RISKKERNEL_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("set RISKKERNEL_TEST_DATABASE_URL to a disposable Postgres to run the Postgres conformance suite")
+	}
+	resetPublicSchema(t, dsn)
+
+	s, err := OpenPostgres(dsn)
+	if err != nil {
+		t.Fatalf("OpenPostgres: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	storeConformance(t, s)
+}
+
+// TestPostgresMigrateDowngradeProtection asserts Postgres refuses to start when the
+// on-disk schema is newer than the binary understands (the same downgrade guard the
+// SQLite backend enforces).
+func TestPostgresMigrateDowngradeProtection(t *testing.T) {
+	dsn := os.Getenv("RISKKERNEL_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("set RISKKERNEL_TEST_DATABASE_URL to run the Postgres downgrade-protection test")
+	}
+	resetPublicSchema(t, dsn)
+
+	s, err := OpenPostgres(dsn)
+	if err != nil {
+		t.Fatalf("OpenPostgres: %v", err)
+	}
+	// Pretend a newer binary has run by recording a future migration version.
+	max, err := maxMigrationVersionFS(pgMigrationsFS, pgMigrationsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.db.ExecContext(context.Background(),
+		`INSERT INTO goose_db_version (version_id, is_applied, tstamp) VALUES ($1, true, now())`, max+1)
+	if err != nil {
+		t.Fatalf("seed future version: %v", err)
+	}
+	_ = s.Close()
+
+	if _, err := OpenPostgres(dsn); err == nil {
+		t.Fatal("OpenPostgres should refuse a schema newer than the binary")
+	}
+}
+
+// resetPublicSchema drops and recreates the public schema so each run starts on a
+// clean database.
+func resetPublicSchema(t *testing.T, dsn string) {
+	t.Helper()
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open for reset: %v", err)
+	}
+	defer db.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := db.ExecContext(ctx, `DROP SCHEMA public CASCADE; CREATE SCHEMA public;`); err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+}


### PR DESCRIPTION
SQLite is the right default — zero-config, a single file you own. This adds an
**opt-in Postgres backend** behind the same `Store` interface for multi-instance /
HA deployments, selected by setting `RISKKERNEL_DATABASE_URL`. Nothing changes
unless you set it.

```bash
export RISKKERNEL_DATABASE_URL="postgres://user:pass@host:5432/riskkernel?sslmode=require"
riskkernel serve   # logs: state store ready  backend=postgres
```

## Design
The Postgres schema mirrors SQLite's exactly — timestamps as RFC3339 text, JSON
marshaled in the application — so **every package-level scan/marshal helper is
reused**; only the SQL dialect (placeholder style, the metadata JSON accessor) and
the DDL differ. The existing SQLite backend is **left completely untouched**, so
there's zero risk to the crash-resume path it already powers.

- Forward-only migrations on startup via embedded Goose, with the same downgrade
  protection (refuse to boot on a schema newer than the binary).
- Implements the full `Store`: runs, steps, the cost ledger and its summaries
  (including metadata grouping), tool-call audit trail, memory facts, approvals,
  policy bundles, and crash-resumable checkpoints.
- Driver: `github.com/jackc/pgx/v5`, used via `database/sql` so the query layer
  stays shared in style with SQLite. (+3 small transitive `jackc/*` helpers.)

## Tests
- A **shared `Store` conformance suite** (`conformance_test.go`) runs against
  **both** backends, so a query that works on one but not the other fails CI.
  `TestSQLiteConformance` runs in ordinary CI; `TestPostgresConformance` /
  `TestPostgresMigrateDowngradeProtection` run when `RISKKERNEL_TEST_DATABASE_URL`
  points at a disposable Postgres (CI provides one as a service).
- **Verified against a real Postgres 18 locally:** the conformance suite and the
  downgrade-protection test pass, and a **daemon restart against shared Postgres
  state reloaded an in-flight run and kept enforcing its already-spent budget** —
  crash-resume works across instances, not just on SQLite.
- `go test -race ./...` green; `go vet ./...` clean; `gofmt` clean.

Docs: [`docs/POSTGRES.md`](docs/POSTGRES.md); compatibility posture updated in
`COMPATIBILITY.md` (both schemas forward-migratable, parity held by the conformance
suite).

Closes #25
