### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-14
+
+Reach and scale. RiskKernel now plugs into the whole Python agent ecosystem —
+adapters for **LlamaIndex, CrewAI, AutoGen, and PydanticAI** join the existing
+LangChain and OpenAI/Claude Agent SDK adapters — and completes the OpenTelemetry
+surface with an **OTLP trace ingress** that meters apps it didn't proxy. Streaming
+now works on **both** the OpenAI- and Anthropic-compatible endpoints, a native
+**Ollama** provider runs local models, and an opt-in **Postgres** backend takes the
+state layer multi-instance. Plus operability: a Prometheus **`/metrics`** endpoint,
+shell completions, **`riskkernel doctor`**, and per-run policy enforcement. No
+breaking API changes; forward-compatible with v0.6.x state.
+
 ### Added
 - **Postgres storage backend (opt-in).** For multi-instance / HA deployments,
   RiskKernel can run its state on Postgres instead of the default SQLite file — set
@@ -450,7 +462,8 @@ and a memory you own, in one self-hosted binary. Three integration surfaces
   (keyless) on each `v*` tag; GoReleaser binaries + checksums + GitHub release;
   `govulncheck` + CodeQL in CI. One-line `docker run` quickstart.
 
-[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/prashar32/riskkernel/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/prashar32/riskkernel/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/prashar32/riskkernel/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/prashar32/riskkernel/compare/v0.3.0...v0.4.0

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -71,7 +71,7 @@ orchestration inside the runtime, and a required heavyweight datastore.
 
 ## Status & roadmap
 
-v0.6.0 (released). The runtime is the entire current focus. See
+v0.7.0 (released). The runtime is the entire current focus. See
 [`CHANGELOG.md`](../CHANGELOG.md) for what has landed and the public contract in
 [`api/v1/`](../api/v1) for the stable surface SDKs build on.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ package version
 // These are set via -ldflags "-X github.com/prashar32/riskkernel/internal/version.Version=..."
 var (
 	// Version is the semantic version of this build.
-	Version = "0.6.1-dev"
+	Version = "0.7.1-dev"
 	// Commit is the git commit this binary was built from.
 	Commit = "unknown"
 	// Date is the build date (RFC3339), stamped at release.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "riskkernel"
-version = "0.6.0"
+version = "0.7.0"
 description = "Thin Python client for the RiskKernel reliability runtime (Surface 2)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdks/python/riskkernel/__init__.py
+++ b/sdks/python/riskkernel/__init__.py
@@ -37,7 +37,7 @@ from .runtime import (
     governed_run,
 )
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 __all__ = [
     "RiskKernel",


### PR DESCRIPTION
Cuts **v0.7.0**. Rolls the `[Unreleased]` changelog into a dated `## [0.7.0]` section (with the compare links), updates the `docs/VISION.md` status line, bumps the in-binary dev version to `0.7.1-dev`, and bumps the Python SDK to `0.7.0` (`pyproject.toml` + `__init__.py`).

This release: four new framework adapters (LlamaIndex, CrewAI, AutoGen, PydanticAI), OTLP trace ingress (the consume side of Surface 3), streaming on both the OpenAI- and Anthropic-compatible endpoints, a native Ollama provider, an opt-in Postgres backend, plus a Prometheus `/metrics` endpoint, shell completions, `riskkernel doctor`, and per-run policy enforcement. No breaking API changes; forward-compatible with v0.6.x state.

After merge: tag `v0.7.0` on the merged commit (CI builds + signs the multi-arch image and binaries).