### PR TITLE
fix(ci): publish the TypeScript SDK for v0.7.0

### DIFF
--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -24,6 +24,10 @@ name: Publish TypeScript SDK
 on:
   push:
     tags: ["v*"]
+  # Manual re-publish: if a tag shipped before package.json was bumped, fix the
+  # version on a branch and run this workflow from that ref. Publishing is
+  # idempotent (it skips a version already on npm), so a manual run is safe.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -53,7 +57,10 @@ jobs:
         run: npm ci
 
       # Don't publish a version that doesn't match the tag that triggered this.
+      # Only meaningful for a tag push; a manual dispatch publishes whatever
+      # package.json declares (still guarded by the idempotent publish below).
       - name: Verify package version matches the tag
+        if: github.event_name == 'push'
         run: |
           tag="${GITHUB_REF_NAME#v}"
           pkg="$(node -p "require('./package.json').version")"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@riskkernel/sdk",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@riskkernel/sdk",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@ai-sdk/provider": "^2.0.3",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riskkernel/sdk",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Thin TypeScript client for the RiskKernel reliability runtime (Surface 2).",
   "license": "Apache-2.0",
   "author": "Adarsh Prashar",


### PR DESCRIPTION
The v0.7.0 `Publish TypeScript SDK` run failed with `tag v0.7.0 does not match package.json version 0.6.0` — `sdks/typescript/package.json` wasn't bumped in the release PR, and the workflow's version guard correctly refused to publish a mismatched version. (The Go release and the Python SDK publish both succeeded; only the TS SDK is missing from npm.)

This:
- Bumps `sdks/typescript/package.json` and the two `package-lock.json` version fields to **0.7.0** (surgical edits — no dependency re-resolution; `npm ci` stays consistent, 0 vulnerabilities).
- Adds a **`workflow_dispatch`** trigger to `typescript-publish.yml` and skips the tag-match guard on a manual run, so the SDK can be re-published from a branch without re-tagging the whole release. Publishing stays idempotent (skips a version already on npm).

After merge I'll run the publish workflow from `main` to push `@riskkernel/sdk@0.7.0`, leaving the already-published, signed Go release and the Python SDK untouched.

Verified locally: `npm ci` + `npm run typecheck` + `npm test` + `npm run build` all pass; `npm audit` reports 0 vulnerabilities.