### PR TITLE
release: v0.8.0

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,7 +51,7 @@ work around it. Stability of the public surface is governed by
 |---|---|
 | `governor` | **The disposer.** Hard per-run token/dollar/loop/wall-clock budgets + kill switch. The headline; most-tested. |
 | `pricing` | Deterministic USD pricing of token usage (static, config-overridable table). |
-| `provider` | LLM provider abstraction (`Provider` interface). Native Anthropic; OpenAI/Bedrock/Ollama stubbed. The only outbound LLM calls. |
+| `provider` | LLM provider abstraction (`Provider` interface). Native: Anthropic, OpenAI, Ollama, AWS Bedrock (SigV4-signed). The only outbound LLM calls. |
 | `runs` | The run manager — identity + lifecycle around a `governor.Run`; write-through persistence; crash-resume reload. |
 | `storage` | The `Store` interface + SQLite backend; embedded forward-only Goose migrations. The file the user owns. |
 | `approval` | Human-in-the-loop gate: deterministic policy match + a queue that blocks a side-effecting call until resolved. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-20
+
+Broader reach. A native **AWS Bedrock** provider (hand-rolled SigV4, no AWS SDK)
+joins Anthropic / OpenAI / Ollama, with the long tail of providers documented via
+**LiteLLM upstream**. **`brew install`** packaging lands; **Datadog** and **SigNoz**
+dashboards join the Grafana one; and cross-run **spend rollups**
+(`riskkernel audit summary --by metadata.team`, with run name/tags on the OTel spans)
+make spend-by-team real. Plus a refreshed built-in pricing table tracking the current
+provider list prices. No breaking API changes; forward-compatible with v0.7.x state.
+
 ### Added
 - **Homebrew formula publishing.** A release workflow + formula generator publish the
   `riskkernel` formula to a Homebrew tap on each version tag, so `brew install
@@ -553,7 +563,8 @@ and a memory you own, in one self-hosted binary. Three integration surfaces
   (keyless) on each `v*` tag; GoReleaser binaries + checksums + GitHub release;
   `govulncheck` + CodeQL in CI. One-line `docker run` quickstart.
 
-[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/prashar32/riskkernel/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/prashar32/riskkernel/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/prashar32/riskkernel/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/prashar32/riskkernel/compare/v0.4.0...v0.5.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,17 +44,17 @@ The core runtime is built and released:
   with adapters for the Claude Agent SDK, OpenAI Agents, LangChain, LlamaIndex,
   CrewAI, AutoGen, and PydanticAI (Python), and the Vercel AI SDK (TypeScript).
 - **Operability** — a Prometheus `/metrics` endpoint, a `riskkernel doctor` setup
-  check, shell completions, and a one-command `docker compose` quickstart.
+  check, shell completions, a one-command `docker compose` quickstart, and a
+  Homebrew tap (`brew install riskkernel`).
 - **Measured, low overhead** — the enforcement decision is ~150 ns and zero
   allocations per call, with a reproducible cost benchmark and a timed `kill -9`
   recovery benchmark (exact-once spend) behind the claims ([`docs/PERFORMANCE.md`](docs/PERFORMANCE.md)).
 
 ## Next
 
-Where the work is heading near-term:
-
-- **Easier install** — a Homebrew tap for `brew install riskkernel`
-  ([#97](https://github.com/prashar32/riskkernel/issues/97)).
+The headline runtime is built out. Near-term work is now driven by what real usage
+asks for — provider/adapter additions, pricing refreshes, and operability polish as
+they're requested. Have a need? Open an issue; it shapes this list directly.
 
 ## Exploring
 

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -71,7 +71,7 @@ orchestration inside the runtime, and a required heavyweight datastore.
 
 ## Status & roadmap
 
-v0.7.0 (released). The runtime is the entire current focus. See
+v0.8.0 (released). The runtime is the entire current focus. See
 [`CHANGELOG.md`](../CHANGELOG.md) for what has landed and the public contract in
 [`api/v1/`](../api/v1) for the stable surface SDKs build on.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ package version
 // These are set via -ldflags "-X github.com/prashar32/riskkernel/internal/version.Version=..."
 var (
 	// Version is the semantic version of this build.
-	Version = "0.7.1-dev"
+	Version = "0.8.1-dev"
 	// Commit is the git commit this binary was built from.
 	Commit = "unknown"
 	// Date is the build date (RFC3339), stamped at release.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "riskkernel"
-version = "0.7.0"
+version = "0.8.0"
 description = "Thin Python client for the RiskKernel reliability runtime (Surface 2)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdks/python/riskkernel/__init__.py
+++ b/sdks/python/riskkernel/__init__.py
@@ -37,7 +37,7 @@ from .runtime import (
     governed_run,
 )
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 __all__ = [
     "RiskKernel",

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@riskkernel/sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@riskkernel/sdk",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@ai-sdk/provider": "^2.0.3",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riskkernel/sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Thin TypeScript client for the RiskKernel reliability runtime (Surface 2).",
   "license": "Apache-2.0",
   "author": "Adarsh Prashar",


### PR DESCRIPTION
Cuts **v0.8.0**. Rolls `[Unreleased]` into a dated `## [0.8.0]` section (with compare links), updates the `docs/VISION.md` status line, bumps the in-binary dev version to `0.8.1-dev`, and bumps **all three** SDK/version markers — Python (`pyproject.toml` + `__init__.py`) **and the TypeScript SDK** (`package.json` + `package-lock.json`, the marker that was missed at v0.7.0 and broke the npm publish).

Since v0.7.0: native **AWS Bedrock** provider, **Homebrew** publishing, **Datadog** + **SigNoz** dashboards, **LiteLLM** long-tail provider docs, cross-run **spend rollups** (`audit summary`), and a **refreshed pricing** table. No breaking API changes; forward-compatible with v0.7.x state.

After merge: I'll sync main and tag `v0.8.0` on the merged commit (release workflow → signed multi-arch image + binaries; the Python/TS publish workflows push to PyPI/npm) — on your go.

Verified: `go build ./...` clean; `npm ci` in sdks/typescript confirms the lockfile is consistent with the bumped version; CHANGELOG `[Unreleased]` is empty above `[0.8.0]`.