### PR TITLE
docs: Homebrew tap is live (brew install riskkernel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
 
+### Added
+- **Homebrew tap is live.** `brew install prashar32/riskkernel/riskkernel` now
+  installs RiskKernel as a prebuilt binary on macOS and Linux. The
+  [`prashar32/homebrew-riskkernel`](https://github.com/prashar32/homebrew-riskkernel)
+  tap is published with the current formula; README and [`docs/HOMEBREW.md`](docs/HOMEBREW.md)
+  cover install and how the formula stays current on each release.
+
 ## [0.8.0] - 2026-06-20
 
 Broader reach. A native **AWS Bedrock** provider (hand-rolled SigV4, no AWS SDK)

--- a/README.md
+++ b/README.md
@@ -100,12 +100,15 @@ Prefer a native binary to Docker? Install the CLI with one command — no clone
 needed — and run it:
 
 ```bash
+brew install prashar32/riskkernel/riskkernel    # macOS / Linux (Homebrew)
+# or:
 go install github.com/prashar32/riskkernel/cmd/riskkernel@latest
+
 riskkernel init      # scaffold a .env + a runnable example in the current dir
 riskkernel serve     # start the daemon (reads .env)
 ```
 
-(or `make build` from a clone, or Homebrew — see [`docs/HOMEBREW.md`](docs/HOMEBREW.md)).
+(or `make build` from a clone; more on the tap in [`docs/HOMEBREW.md`](docs/HOMEBREW.md)).
 Tab-complete the CLI in your shell:
 
 ```bash

--- a/docs/HOMEBREW.md
+++ b/docs/HOMEBREW.md
@@ -12,10 +12,8 @@ brew install riskkernel
 This pulls the signed release binary for your OS/arch (no compile). Upgrade with
 `brew upgrade riskkernel`.
 
-> **Status:** the publishing automation is in the repo, but `brew install` works only
-> once the tap repo and token are set up (one-time maintainer step, below). Until
-> then, install via `go install`, `docker run`, or the release binaries — see the
-> [README quickstart](../README.md#quickstart-60-seconds).
+The tap ([prashar32/homebrew-riskkernel](https://github.com/prashar32/homebrew-riskkernel))
+is live, with the formula tracking the latest release.
 
 ## How it works
 
@@ -26,22 +24,22 @@ formula with a per-OS/arch `url` + `sha256` taken from the GoReleaser archives),
 commits it to the tap repo as `Formula/riskkernel.rb`. It mirrors how the Python and
 TypeScript SDKs publish on a tag.
 
-## Maintainer setup (one-time, to activate)
+## Keeping the formula current
 
-The workflow is **inert until two things exist** — without them it logs a notice and
-exits 0, so it never blocks a release:
+The tap repo **`prashar32/homebrew-riskkernel`** exists and is seeded with the
+current formula, so `brew install` works today. There are two ways to update it on
+future releases:
 
-1. **Create the tap repo.** A *public* repo named **`homebrew-riskkernel`** under the
-   same owner (`prashar32`). Homebrew requires the `homebrew-` name prefix; it maps to
-   the tap `prashar32/riskkernel`. It can start empty — the workflow writes
-   `Formula/riskkernel.rb`.
-2. **Add the token secret.** On the `prashar32/riskkernel` repo, add an Actions secret
-   **`HOMEBREW_TAP_TOKEN`**: a fine-grained personal access token scoped to the
-   `homebrew-riskkernel` repo with **Contents: read and write**.
-
-Then publish the current release: re-run the **Publish Homebrew formula** workflow
-(Actions → *Run workflow*), or just cut the next release — it runs automatically on
-each `v*` tag.
+- **Hands-free (recommended):** add an Actions secret **`HOMEBREW_TAP_TOKEN`** on the
+  `prashar32/riskkernel` repo — a fine-grained PAT scoped to the `homebrew-riskkernel`
+  repo with **Contents: read and write**. The `Publish Homebrew formula` workflow then
+  pushes the formula automatically on every `v*` tag. Without the secret the workflow
+  logs a notice and exits 0 (it never blocks a release).
+- **Manual:** run the generator against a release's checksums and push to the tap:
+  ```bash
+  gh release download vX.Y.Z --repo prashar32/riskkernel --pattern checksums.txt --dir /tmp/r
+  scripts/gen-homebrew-formula.sh X.Y.Z /tmp/r/checksums.txt > Formula/riskkernel.rb  # in the tap repo
+  ```
 
 > On the eventual org transfer (`prashar32` → a `riskkernel` org), move the tap repo
 > and re-point the `TAP_REPO` in the workflow, the same way the PyPI/npm trusted


### PR DESCRIPTION
The `prashar32/homebrew-riskkernel` tap is now published with the current formula — `brew install prashar32/riskkernel/riskkernel` works (verified: `brew fetch` sha-checks the v0.8.0 asset, `brew install` + `riskkernel version` → 0.8.0).

This makes Homebrew a first-class install path in the README, updates `docs/HOMEBREW.md` (tap exists; future formula updates are hands-free once `HOMEBREW_TAP_TOKEN` is added, or via a manual push), and adds a changelog entry. Docs-only.