### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ surface is governed by [`COMPATIBILITY.md`](COMPATIBILITY.md).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-20
+
+Packaging. The Homebrew tap goes live — `brew install prashar32/riskkernel/riskkernel`
+installs RiskKernel on macOS and Linux, joining `docker run`, `go install`, and the
+SDKs (PyPI / npm). A focused packaging release on top of v0.8.0's feature set; no
+runtime or API changes.
+
 ### Added
 - **Homebrew tap is live.** `brew install prashar32/riskkernel/riskkernel` now
   installs RiskKernel as a prebuilt binary on macOS and Linux. The
@@ -570,7 +577,8 @@ and a memory you own, in one self-hosted binary. Three integration surfaces
   (keyless) on each `v*` tag; GoReleaser binaries + checksums + GitHub release;
   `govulncheck` + CodeQL in CI. One-line `docker run` quickstart.
 
-[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/prashar32/riskkernel/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/prashar32/riskkernel/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/prashar32/riskkernel/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/prashar32/riskkernel/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/prashar32/riskkernel/compare/v0.5.0...v0.6.0

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -71,7 +71,7 @@ orchestration inside the runtime, and a required heavyweight datastore.
 
 ## Status & roadmap
 
-v0.8.0 (released). The runtime is the entire current focus. See
+v0.9.0 (released). The runtime is the entire current focus. See
 [`CHANGELOG.md`](../CHANGELOG.md) for what has landed and the public contract in
 [`api/v1/`](../api/v1) for the stable surface SDKs build on.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,7 @@ package version
 // These are set via -ldflags "-X github.com/prashar32/riskkernel/internal/version.Version=..."
 var (
 	// Version is the semantic version of this build.
-	Version = "0.8.1-dev"
+	Version = "0.9.1-dev"
 	// Commit is the git commit this binary was built from.
 	Commit = "unknown"
 	// Date is the build date (RFC3339), stamped at release.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "riskkernel"
-version = "0.8.0"
+version = "0.9.0"
 description = "Thin Python client for the RiskKernel reliability runtime (Surface 2)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdks/python/riskkernel/__init__.py
+++ b/sdks/python/riskkernel/__init__.py
@@ -37,7 +37,7 @@ from .runtime import (
     governed_run,
 )
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 __all__ = [
     "RiskKernel",

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@riskkernel/sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@riskkernel/sdk",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@ai-sdk/provider": "^2.0.3",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riskkernel/sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Thin TypeScript client for the RiskKernel reliability runtime (Surface 2).",
   "license": "Apache-2.0",
   "author": "Adarsh Prashar",


### PR DESCRIPTION
Cuts **v0.9.0** — a focused packaging release on top of v0.8.0: the Homebrew tap is live (`brew install prashar32/riskkernel/riskkernel`). Rolls `[Unreleased]` into `## [0.9.0]` (with compare links), updates the VISION status line, bumps the in-binary dev version to `0.9.1-dev`, and bumps all three SDK markers (Python + TypeScript) to 0.9.0. No runtime or API changes.

Verified: `go build ./...` clean; `npm ci` confirms the TS lockfile is consistent; CHANGELOG `[Unreleased]` empty above `[0.9.0]`.